### PR TITLE
Fix/profile-separate 스프링 프로필 dev, prod 분리

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${LOCAL_DB_URL}:5432/earnedit
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${RDS_DB_URL}:5432/earnedit
+    username: ${RDS_DB_USER}
+    password: ${RDS_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,11 +2,8 @@ spring:
   application:
     name: earnedit
 
-  datasource:
-    url: jdbc:postgresql://${RDS_DB_URL}:5432/earnedit
-    username: ${RDS_DB_USER}
-    password: ${RDS_DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
+  config:
+    import: optional:file:.env[.properties]
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 📌 작업 개요
- dev, prod 프로필 분리 및 DB 연동 안됨 오류 수정했습니다.

---

## ✨ 주요 변경 사항
- application.yaml에 .env 위치 명시 코드가 빠져있었습니다. 추가하여 DB 연결 테스트까지 확인 완료
- dev, prod 프로필 분리하였습니다. 

---

## 🖼️ 기능 살펴 보기


---

## ✅ 작업 체크리스트

---

## 📂 테스트 방법
---

## 💬 기타 참고 사항
```
-Dspring.profiles.active=prod
-Dspring.profiles.active=dev
```
위에서 dev로 설정해서 지난 프로젝트에서 했던 것처럼 실행 구성 편집해주시면 됩니다
---

## 📎 관련 이슈 / 문서

