### PR TITLE
Chore/docker-separate 도커 운영, 개발환경 분리 및 스크립트 파일 추가

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,47 @@
+# 실행법 !!
+# 1. 루트 디렉토리에서 docker compose up -d 실행
+# 2. Docker 앱 구동 또는 터미널에 docker images 입력
+# 3. postgres, earnedit-web 초록불 들어온 것 확인
+# 4. localhost:8080/health 접속 테스트
+# 5. Mysql workbench 또는 Dbeaver 이용하여 DB 연결 (밑에 주석 확인)
+
+version: '3'
+
+services:
+  # postgres DB 이미지
+  database:
+    image: postgres
+    container_name: postgresDB
+    restart: always
+    expose:
+      - 5432
+    ports:
+      - "5432:5432"
+    environment:
+      # 이 부분이 Docker DB 연결 정보. 이 내용을 입력
+      POSTGRES_DB: earnedit
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: earnedit99
+#    volumes:
+#      - ./resources/init.sql # DB 초기화 시 사용
+
+
+  # 웹 서버
+  web:
+    container_name: earned-it
+    build:
+      context: . # build를 실행할 위치
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+
+    env_file:
+      - .env
+
+    environment:
+      # 스프링 프로필 설정
+      SPRING_PROFILES_ACTIVE: dev
+
+
+
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  # 웹 서버
+  web:
+    container_name: earned-it
+    build:
+      context: . # build를 실행할 위치
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+
+    env_file:
+      - .env
+
+    environment:
+      # 스프링 프로필 설정
+      SPRING_PROFILES_ACTIVE: prod
+
+
+
+

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+./gradlew bootJar
+docker compose -f docker-compose.dev.yml up -d --build


### PR DESCRIPTION
## 📌 작업 개요
- 스크립트 파일을 추가하여 소스코드를 변경했을 때 docker 통해 구동되는 웹사이트에 바로 반영될 수 있도록 하였습니다. (start-dev.sh)
- 로컬과 배포에 대해서 각각 docker-compose 파일을 분리했습니다.
---

## ✨ 주요 변경 사항
- 프로젝트 루트 디렉토리에 start-dev.sh 추가하였습니다.
- docker-compose.dev.yml 추가
- docker-compose.prod.yml 추가
- env 파일을 도커 환경에서 참조할 수 있도록 추가

---

## 🖼️ 기능 살펴 보기

```
# 루트 디렉토리에서 
. /start-dev.sh
```
위 명령어 사용하면 빌드 및 도커 재구동까지 자동으로 됩니다! 꼭 확인해주세요!!!!

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Docker 구동 테스트
- 로그 문제 x
---

## 💬 기타 참고 사항
- 

---

## 📎 관련 이슈 / 문서

