### PR TITLE
Feat/signup : 수익 정보 생성 api, 초수익 스케줄러, 이메일토큰검증에 토큰-이메일 검증 추가

### DIFF
--- a/src/main/java/_team/earnedit/EarneditApplication.java
+++ b/src/main/java/_team/earnedit/EarneditApplication.java
@@ -3,8 +3,10 @@ package _team.earnedit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@EnableScheduling
 public class EarneditApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/_team/earnedit/controller/EmailVerificationController.java
+++ b/src/main/java/_team/earnedit/controller/EmailVerificationController.java
@@ -1,5 +1,6 @@
 package _team.earnedit.controller;
 
+import _team.earnedit.dto.auth.EmailTokenVerifyRequestDto;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.EmailVerificationService;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,8 @@ public class EmailVerificationController {
 
     // 이메일 인증 코드 입력 후 검증 (앱 UI에서 코드 입력 후 호출)
     @PostMapping("/verify")
-    public ResponseEntity<ApiResponse<String>> verifyEmailToken(@RequestParam String token) {
-        emailVerificationService.verifyEmailToken(token);
+    public ResponseEntity<ApiResponse<String>> verifyEmailToken(@RequestBody EmailTokenVerifyRequestDto requestDto) {
+        emailVerificationService.verifyEmailToken(requestDto.getEmail(), requestDto.getToken());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success("이메일 인증이 완료되었습니다."));
     }

--- a/src/main/java/_team/earnedit/controller/ProfileController.java
+++ b/src/main/java/_team/earnedit/controller/ProfileController.java
@@ -1,9 +1,17 @@
 package _team.earnedit.controller;
 
+import _team.earnedit.dto.profile.SalaryRequestDto;
+import _team.earnedit.dto.profile.SalaryResponseDto;
+import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.ProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequiredArgsConstructor
@@ -11,5 +19,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ProfileController {
     private final ProfileService profileService;
 
-
+    @PostMapping("/salary")
+    public ResponseEntity<ApiResponse<SalaryResponseDto>> saveSalary(@RequestParam long userId, @RequestBody SalaryRequestDto requestDto) {
+        SalaryResponseDto responseDto = profileService.updateSalary(userId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("수익 정보를 업데이트했습니다",responseDto));
+    }
 }

--- a/src/main/java/_team/earnedit/controller/ProfileController.java
+++ b/src/main/java/_team/earnedit/controller/ProfileController.java
@@ -1,0 +1,15 @@
+package _team.earnedit.controller;
+
+import _team.earnedit.service.ProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/profile")
+public class ProfileController {
+    private final ProfileService profileService;
+
+
+}

--- a/src/main/java/_team/earnedit/dto/auth/EmailTokenVerifyRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/EmailTokenVerifyRequestDto.java
@@ -1,0 +1,13 @@
+package _team.earnedit.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailTokenVerifyRequestDto {
+    private String email;
+    private String token;
+}

--- a/src/main/java/_team/earnedit/dto/profile/SalaryRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/SalaryRequestDto.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 public class SalaryRequestDto {
 
     private Long amount;
+    private Integer payday;
 
 }

--- a/src/main/java/_team/earnedit/dto/profile/SalaryRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/SalaryRequestDto.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Getter
 public class SalaryRequestDto {
 
-    private Long salary;
+    private Long amount;
 
 }

--- a/src/main/java/_team/earnedit/dto/profile/SalaryRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/SalaryRequestDto.java
@@ -1,0 +1,12 @@
+package _team.earnedit.dto.profile;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SalaryRequestDto {
+
+    private Long salary;
+
+}

--- a/src/main/java/_team/earnedit/dto/profile/SalaryResponseDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/SalaryResponseDto.java
@@ -1,4 +1,20 @@
 package _team.earnedit.dto.profile;
 
+import _team.earnedit.entity.Salary;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class SalaryResponseDto {
+
+    private Long amount;
+    private Double amountPerSec;
+
+    public static SalaryResponseDto from(Salary salary) {
+        return SalaryResponseDto.builder()
+                .amount(salary.getAmount())
+                .amountPerSec(salary.getAmountPerSec())
+                .build();
+    }
 }

--- a/src/main/java/_team/earnedit/dto/profile/SalaryResponseDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/SalaryResponseDto.java
@@ -1,0 +1,4 @@
+package _team.earnedit.dto.profile;
+
+public class SalaryResponseDto {
+}

--- a/src/main/java/_team/earnedit/dto/profile/SalaryResponseDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/SalaryResponseDto.java
@@ -10,11 +10,13 @@ public class SalaryResponseDto {
 
     private Long amount;
     private Double amountPerSec;
+    private Integer payday;
 
     public static SalaryResponseDto from(Salary salary) {
         return SalaryResponseDto.builder()
                 .amount(salary.getAmount())
                 .amountPerSec(salary.getAmountPerSec())
+                .payday(salary.getPayday())
                 .build();
     }
 }

--- a/src/main/java/_team/earnedit/entity/Salary.java
+++ b/src/main/java/_team/earnedit/entity/Salary.java
@@ -26,7 +26,7 @@ public class Salary {
     private Boolean severance;
 
     @Column(nullable = false)
-    private Long salary;
+    private Long amount;
 
     private Integer dependentCount;
 
@@ -36,7 +36,7 @@ public class Salary {
     private Boolean tax = false;
 
     @Column(nullable = false)
-    private Double salaryPerSec;
+    private Double amountPerSec;
 
     public enum SalaryType {
         MONTH,

--- a/src/main/java/_team/earnedit/entity/Salary.java
+++ b/src/main/java/_team/earnedit/entity/Salary.java
@@ -43,4 +43,8 @@ public class Salary {
         YEAR,
         NONE
     }
+
+    public void updateAmountPerSec(double newAmountPerSec) {
+        this.amountPerSec = newAmountPerSec;
+    }
 }

--- a/src/main/java/_team/earnedit/entity/Salary.java
+++ b/src/main/java/_team/earnedit/entity/Salary.java
@@ -38,6 +38,9 @@ public class Salary {
     @Column(nullable = false)
     private Double amountPerSec;
 
+    @Column(nullable = false)
+    private Integer payday;
+
     public enum SalaryType {
         MONTH,
         YEAR,

--- a/src/main/java/_team/earnedit/entity/Salary.java
+++ b/src/main/java/_team/earnedit/entity/Salary.java
@@ -1,0 +1,46 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "salary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Salary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SalaryType type;
+
+    private Boolean severance;
+
+    @Column(nullable = false)
+    private Long salary;
+
+    private Integer dependentCount;
+
+    private Long taxExemptAmount;
+
+    @Column(nullable = false)
+    private Boolean tax = false;
+
+    @Column(nullable = false)
+    private Double salaryPerSec;
+
+    public enum SalaryType {
+        MONTH,
+        YEAR,
+        NONE
+    }
+}

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     EMAIL_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
 
+    EMAIL_TOKEN_INVALID_EMAIL(HttpStatus.BAD_REQUEST, "해당 토큰에 대한 이메일이 일치하지 않습니다."),
     EMAIL_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 인증 요청입니다."),
     EMAIL_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "인증 유효시간이 만료되었습니다."),
     EMAIL_TOKEN_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료된 요청입니다."),

--- a/src/main/java/_team/earnedit/global/scheduler/AmountPerSecScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/AmountPerSecScheduler.java
@@ -1,4 +1,34 @@
 package _team.earnedit.global.scheduler;
 
+import _team.earnedit.entity.Salary;
+import _team.earnedit.global.util.SalaryCalculator;
+import _team.earnedit.repository.SalaryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
 public class AmountPerSecScheduler {
+
+    private final SalaryRepository salaryRepository;
+    private final SalaryCalculator salaryCalculator;
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    @Transactional
+    public void updateSalaryPerSecForAllUsers() {
+        List<Salary> salaries = salaryRepository.findAll();
+
+        for (Salary salary : salaries) {
+            double newSalaryPerSec = salaryCalculator.calculateAmountPerSec(salary.getAmount());
+            salary.updateAmountPerSec(newSalaryPerSec);
+        }
+
+        log.info("[스케줄러] 모든 유저 salaryPerSec 갱신 완료");
+    }
 }

--- a/src/main/java/_team/earnedit/global/scheduler/AmountPerSecScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/AmountPerSecScheduler.java
@@ -1,0 +1,4 @@
+package _team.earnedit.global.scheduler;
+
+public class AmountPerSecScheduler {
+}

--- a/src/main/java/_team/earnedit/global/util/SalaryCalculator.java
+++ b/src/main/java/_team/earnedit/global/util/SalaryCalculator.java
@@ -1,0 +1,4 @@
+package _team.earnedit.global.util;
+
+public class SalaryCalculator {
+}

--- a/src/main/java/_team/earnedit/global/util/SalaryCalculator.java
+++ b/src/main/java/_team/earnedit/global/util/SalaryCalculator.java
@@ -1,4 +1,23 @@
 package _team.earnedit.global.util;
 
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
 public class SalaryCalculator {
+
+    public long getCurrentMonthSeconds() {
+        LocalDate now = LocalDate.now();
+        int daysInMonth = now.lengthOfMonth();
+        return daysInMonth * 24L * 60L * 60L;
+    }
+
+    public double calculateAmountPerSec(Long amount) {
+        if (amount == null || amount == 0) {
+            return 0.0;
+        }
+        long secondsInMonth = getCurrentMonthSeconds();
+        return (double) amount / secondsInMonth;
+    }
 }

--- a/src/main/java/_team/earnedit/repository/SalaryRepository.java
+++ b/src/main/java/_team/earnedit/repository/SalaryRepository.java
@@ -1,0 +1,7 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.Salary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SalaryRepository extends JpaRepository<Salary, Long> {
+}

--- a/src/main/java/_team/earnedit/service/EmailVerificationService.java
+++ b/src/main/java/_team/earnedit/service/EmailVerificationService.java
@@ -52,9 +52,13 @@ public class EmailVerificationService {
 
     // 인증 확인 (토큰 검증)
     @Transactional
-    public void verifyEmailToken(String token) {
+    public void verifyEmailToken(String email, String token) {
         EmailToken emailToken = emailTokenRepository.findByToken(token)
                 .orElseThrow(() -> new UserException(ErrorCode.EMAIL_TOKEN_NOT_FOUND));
+
+        if (!emailToken.getEmail().equals(email)) {
+            throw new UserException(ErrorCode.EMAIL_TOKEN_INVALID_EMAIL);
+        }
 
         if (emailToken.isVerified()) {
             throw new UserException(ErrorCode.EMAIL_TOKEN_ALREADY_VERIFIED);

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -18,7 +18,7 @@ public class ProfileService {
 
     public SalaryResponseDto updateSalary(long userId, SalaryRequestDto requestDto) {
         Long amount = requestDto.getAmount();
-        double salaryPerSec = salaryCalculator.calculateAmountPerSec(amount);
+        double amountPerSec = salaryCalculator.calculateAmountPerSec(amount);
 
         Salary salary = salaryRepository.save(
                 Salary.builder()
@@ -26,11 +26,11 @@ public class ProfileService {
                         .type(Salary.SalaryType.MONTH)
                         .amount(amount)
                         .tax(false)
-                        .amountPerSec(salaryPerSec)
+                        .amountPerSec(amountPerSec)
                         .build()
         );
 
-        return new SalaryResponseDto();
+        return SalaryResponseDto.from(salary);
     }
 
     // 수익 조회용 (예정)

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -4,6 +4,7 @@ import _team.earnedit.dto.profile.SalaryRequestDto;
 import _team.earnedit.dto.profile.SalaryResponseDto;
 import _team.earnedit.entity.Salary;
 import _team.earnedit.entity.User;
+import _team.earnedit.global.util.SalaryCalculator;
 import _team.earnedit.repository.SalaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,29 +14,23 @@ import org.springframework.stereotype.Service;
 public class ProfileService {
 
     private final SalaryRepository salaryRepository;
+    private final SalaryCalculator salaryCalculator;
 
     public SalaryResponseDto updateSalary(long userId, SalaryRequestDto requestDto) {
         Long amount = requestDto.getAmount();
+        double salaryPerSec = salaryCalculator.calculateAmountPerSec(amount);
 
         Salary salary = salaryRepository.save(
                 Salary.builder()
-                        .user(User.builder().id(userId).build())  // 연관관계 설정 (프록시로 처리)
-                        .type(Salary.SalaryType.MONTH)            // 무조건 MONTH
-                        .amount(amount)                           // 월 수령액
-                        .tax(false)                               // 무조건 false
-                        .amountPerSec(calculateSalaryPerSec(amount)) // 계산해서 저장
+                        .user(User.builder().id(userId).build())
+                        .type(Salary.SalaryType.MONTH)
+                        .amount(amount)
+                        .tax(false)
+                        .amountPerSec(salaryPerSec)
                         .build()
         );
 
         return new SalaryResponseDto();
-    }
-
-    private double calculateSalaryPerSec(Long amount) {
-        if (amount == null || amount == 0) {
-            return 0.0;
-        }
-        long secondsInMonth = 30L * 24L * 60L * 60L;  // 월 기준 30일
-        return (double) amount / secondsInMonth;
     }
 
     // 수익 조회용 (예정)

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -18,6 +18,7 @@ public class ProfileService {
 
     public SalaryResponseDto updateSalary(long userId, SalaryRequestDto requestDto) {
         Long amount = requestDto.getAmount();
+        Integer payday = requestDto.getPayday();
         double amountPerSec = salaryCalculator.calculateAmountPerSec(amount);
 
         Salary salary = salaryRepository.save(
@@ -27,6 +28,7 @@ public class ProfileService {
                         .amount(amount)
                         .tax(false)
                         .amountPerSec(amountPerSec)
+                        .payday(payday)
                         .build()
         );
 

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -13,7 +13,7 @@ public class ProfileService {
 
     private final SalaryRepository salaryRepository;
 
-    public SalaryResponseDto updateSalary(SalaryRequestDto requestDto) {
+    public SalaryResponseDto updateSalary(long userId, SalaryRequestDto requestDto) {
         Long amount = requestDto.getAmount();
         Salary salary = salaryRepository.save(
                 Salary.builder()

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -3,6 +3,7 @@ package _team.earnedit.service;
 import _team.earnedit.dto.profile.SalaryRequestDto;
 import _team.earnedit.dto.profile.SalaryResponseDto;
 import _team.earnedit.entity.Salary;
+import _team.earnedit.entity.User;
 import _team.earnedit.repository.SalaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,14 +16,29 @@ public class ProfileService {
 
     public SalaryResponseDto updateSalary(long userId, SalaryRequestDto requestDto) {
         Long amount = requestDto.getAmount();
+
         Salary salary = salaryRepository.save(
                 Salary.builder()
-                        .amount(amount)
+                        .user(User.builder().id(userId).build())  // 연관관계 설정 (프록시로 처리)
+                        .type(Salary.SalaryType.MONTH)            // 무조건 MONTH
+                        .amount(amount)                           // 월 수령액
+                        .tax(false)                               // 무조건 false
+                        .amountPerSec(calculateSalaryPerSec(amount)) // 계산해서 저장
                         .build()
         );
+
         return new SalaryResponseDto();
     }
 
+    private double calculateSalaryPerSec(Long amount) {
+        if (amount == null || amount == 0) {
+            return 0.0;
+        }
+        long secondsInMonth = 30L * 24L * 60L * 60L;  // 월 기준 30일
+        return (double) amount / secondsInMonth;
+    }
+
+    // 수익 조회용 (예정)
 //    public SalaryResponseDto getSalary() {
 //
 //    }

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -1,0 +1,29 @@
+package _team.earnedit.service;
+
+import _team.earnedit.dto.profile.SalaryRequestDto;
+import _team.earnedit.dto.profile.SalaryResponseDto;
+import _team.earnedit.entity.Salary;
+import _team.earnedit.repository.SalaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final SalaryRepository salaryRepository;
+
+    public SalaryResponseDto updateSalary(SalaryRequestDto requestDto) {
+        Long amount = requestDto.getAmount();
+        Salary salary = salaryRepository.save(
+                Salary.builder()
+                        .amount(amount)
+                        .build()
+        );
+        return new SalaryResponseDto();
+    }
+
+//    public SalaryResponseDto getSalary() {
+//
+//    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 수익 정보 생성 api
- 초수익 스케줄러
- 이메일토큰검증에 토큰-이메일 검증 추가 @PlayTheApp 

---

## ✨ 주요 변경 사항
- Salary 엔티티 정의
  - 회의 내용 반영 : 컬럼명 amout 통일 및 월급일 컬럼(payday) 추가 -> 노션 반영 완
- profile 파일명으로 생성하여 구현 -> 수익 정보 처리는 프로필 영역
- 월마다 일수가 다르므로 스케줄러에서 초수익 계산값 업데이트
- 이메일토큰검증에 토큰-이메일 검증 추가
  - 회의 내용 반영

---

## 🖼️ 기능 살펴 보기
> 수익 정보 생성 api
<img width="1734" height="1522" alt="image" src="https://github.com/user-attachments/assets/4e69fb57-f6d2-4995-9c2c-ef16430e257d" />

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman , local

---

## 💬 기타 참고 사항
- 스웨거 붙여야함

---

## 📎 관련 이슈 / 문서

