### PR TITLE
Feat/signin : 로그인api 및 기능 구현 (jwt + redis)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,23 @@ dependencies {
 
 	// swagger ui
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+	// jjwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// 시큐리티
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Cache
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # 실행법 !!
 # 1. 루트 디렉토리에서 docker compose up -d 실행
 # 2. Docker 앱 구동 또는 터미널에 docker images 입력
-# 3. postgres, earnedit-web 초록불 들어온 것 확인
+# 3. postgres, earnedit-web, redis 초록불 들어온 것 확인
 # 4. localhost:8080/health 접속 테스트
 # 5. Mysql workbench 또는 Dbeaver 이용하여 DB 연결 (밑에 주석 확인)
 
@@ -26,6 +26,14 @@ services:
 #    volumes:
 #      - ./resources/init.sql # DB 초기화 시 사용
 
+  # Redis 서버
+  redis:
+    image: redis:7.2
+    container_name: redis
+    restart: always
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--requirepass", "12341234"]
 
   # 웹 서버
   web:

--- a/src/main/java/_team/earnedit/config/RedisConfig.java
+++ b/src/main/java/_team/earnedit/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package _team.earnedit.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+        config.setPassword(redisPassword);
+
+        LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofSeconds(5))
+                .build();
+
+        return new LettuceConnectionFactory(config, clientConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/_team/earnedit/config/security/SecurityConfig.java
+++ b/src/main/java/_team/earnedit/config/security/SecurityConfig.java
@@ -1,0 +1,15 @@
+package _team.earnedit.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/_team/earnedit/controller/AuthController.java
+++ b/src/main/java/_team/earnedit/controller/AuthController.java
@@ -1,5 +1,7 @@
 package _team.earnedit.controller;
 
+import _team.earnedit.dto.auth.SignInRequestDto;
+import _team.earnedit.dto.auth.SignInResponseDto;
 import _team.earnedit.dto.auth.SignUpRequestDto;
 import _team.earnedit.dto.auth.SignUpResponseDto;
 import _team.earnedit.global.ApiResponse;
@@ -22,5 +24,11 @@ public class AuthController {
         SignUpResponseDto responseDto = authService.signUp(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("회원가입이 완료되었습니다.", responseDto));
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<SignInResponseDto> signIn(@RequestBody SignInRequestDto requestDto) {
+        SignInResponseDto responseDto = authService.signIn(requestDto);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/_team/earnedit/controller/ProfileController.java
+++ b/src/main/java/_team/earnedit/controller/ProfileController.java
@@ -7,13 +7,9 @@ import _team.earnedit.service.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/profile")
 public class ProfileController {

--- a/src/main/java/_team/earnedit/dto/auth/SignInRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/SignInRequestDto.java
@@ -1,0 +1,9 @@
+package _team.earnedit.dto.auth;
+
+import lombok.Getter;
+
+@Getter
+public class SignInRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/_team/earnedit/dto/auth/SignInResponseDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/SignInResponseDto.java
@@ -1,0 +1,12 @@
+package _team.earnedit.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignInResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+}

--- a/src/main/java/_team/earnedit/dto/jwt/JwtUserInfoDto.java
+++ b/src/main/java/_team/earnedit/dto/jwt/JwtUserInfoDto.java
@@ -1,0 +1,10 @@
+package _team.earnedit.dto.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtUserInfoDto {
+    private Long userId;
+}

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -13,6 +13,12 @@ public enum ErrorCode {
 
     // 회원 User
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "가입된 이메일이 아닙니다."),
+    INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "탈퇴한 회원입니다."),
+
+    // 인증 Authentication
+    AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
 
     // 이메일 인증
     EMAIL_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
@@ -37,11 +37,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         // 헤더에서 토큰 추출
         String token = jwtUtil.resolveToken(request);
 
-//        // Authorization 헤더 없을 경우 쿠키에서 추출 (SSE)
-//        if (token == null) {
-//            token = jwtUtil.extractTokenFromCookies(request);
-//        }
-
         // 토큰 유효성 검사
         try {
             if (token != null && jwtUtil.validateAccessToken(token)) {

--- a/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
@@ -1,0 +1,80 @@
+package _team.earnedit.global.jwt;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final Cache<String, Boolean> expiredTokenLogCache = Caffeine.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES) // 5분 후 삭제
+            .maximumSize(1000) // 최대 1000개
+            .build();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 헤더에서 토큰 추출
+        String token = jwtUtil.resolveToken(request);
+
+//        // Authorization 헤더 없을 경우 쿠키에서 추출 (SSE)
+//        if (token == null) {
+//            token = jwtUtil.extractTokenFromCookies(request);
+//        }
+
+        // 토큰 유효성 검사
+        try {
+            if (token != null && jwtUtil.validateAccessToken(token)) {
+
+                // 로그아웃(블랙리스트) 체크
+                if (redisTemplate.hasKey("BL:" + token)) {
+                    log.warn("블랙리스트 토큰 접근 시도: {}", token);
+                    throw new AuthenticationException("BLACKLISTED") {
+                    };
+                }
+
+                Claims claims = jwtUtil.parseClaims(token);
+                Long userId = Long.valueOf(claims.getSubject());
+
+                // 인증 객체 생성
+                JwtUserInfoDto userInfo = new JwtUserInfoDto(userId);
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userInfo, null, null);
+
+                // 시큐리티 컨텍스트에 저장
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        } catch (ExpiredJwtException e) {
+            if (expiredTokenLogCache.getIfPresent(token) == null) {
+                log.warn("만료된 JWT: {}", e.getMessage());
+                expiredTokenLogCache.put(token, true);
+            }
+        }
+        filterChain.doFilter(request,response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.equals("/api/auth/refresh") || path.startsWith("/swagger") || path.startsWith("/v3/api-docs");
+    }
+}

--- a/src/main/java/_team/earnedit/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/_team/earnedit/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package _team.earnedit.global.jwt;
+
+import _team.earnedit.global.ErrorResponse;
+import _team.earnedit.global.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+
+        ErrorResponse errorResponse = ErrorResponse.fail(ErrorCode.AUTH_REQUIRED);
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/src/main/java/_team/earnedit/global/jwt/JwtUtil.java
+++ b/src/main/java/_team/earnedit/global/jwt/JwtUtil.java
@@ -1,0 +1,141 @@
+package _team.earnedit.global.jwt;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private static final long MINUTE = 60 * 1000L;
+    private static final long HOUR = 60 * MINUTE;
+    private static final long DAY = 24 * HOUR;
+
+    private final Key accessKey;
+    private final Key refreshKey;
+    private final long accessTokenExpireTime;
+    private final long refreshTokenExpireTime;
+
+    // 시크릿 키 만료 시간 설정
+    public JwtUtil(@Value("${jwt.secret}") String accessSecretKey,
+                   @Value("${jwt.refresh_secret}") String refreshSecretKey) {
+        this.accessKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(accessSecretKey));
+        this.refreshKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(refreshSecretKey));
+        this.accessTokenExpireTime = 15 * MINUTE;
+        this.refreshTokenExpireTime = 7 * DAY;
+    }
+
+    //토큰 생성 - access, refresh 발급
+    public String[] generateToken(JwtUserInfoDto user) {
+        String accessToken = generateToken(user, accessKey, accessTokenExpireTime);
+        String refreshToken = generateToken(user, refreshKey, refreshTokenExpireTime);
+        return new String[]{accessToken, refreshToken};
+    }
+
+    // JWT 생성
+    private String generateToken(JwtUserInfoDto user, Key key, long expireTime) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getUserId()))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expireTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // access 재발급
+    public String generateAccessToken(JwtUserInfoDto user) {
+        return generateToken(user, accessKey, accessTokenExpireTime);
+    }
+
+    // AccessToken 검증
+    public boolean validateAccessToken(String token) {
+        return validateToken(token, accessKey);
+    }
+
+    //RefreshToken 검증
+    public boolean validateRefreshToken(String token) {
+        return validateToken(token, refreshKey);
+    }
+
+    // 토큰 검증
+    private boolean validateToken(String token, Key key) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    // JWT에서 Claims 추출
+    // 내부용
+    private Claims parseClaims(String token, Key key) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+    // 외부 파싱용
+    public Claims parseClaims(String token) {
+        return parseClaims(token, accessKey);
+    }
+
+    // 토큰에서 userId 추출
+    public String getUserIdFromToken(String token) {
+        return parseClaims(token, accessKey).getSubject();
+    }
+
+    public String getUserIdFromRefreshToken(String token) {
+        return parseClaims(token, refreshKey).getSubject();
+    }
+
+    // 토큰 추출
+    // 요청 헤더에서 꺼낼 때
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7).trim();
+        }
+        return null;
+    }
+    // 문자열로 토큰 받았을 때 정제용
+    public String extractBearerPrefix(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            return token.substring(7).trim();
+        }
+        return token;
+    }
+
+    // 쿠키에서 access_token 꺼내기
+    public String extractTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    // 만료시간 확인
+    public Date getAccessTokenExpiration(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(accessKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+    }
+}

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -3,10 +3,13 @@ package _team.earnedit.repository;
 import _team.earnedit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
 
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -41,13 +41,13 @@ public class AuthService {
             throw new UserException(ErrorCode.EMAIL_NOT_VERIFIED);
         }
 
-        String password = requestDto.getPassword();
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
         String nickname = generateUniqueNickname();
 
         User user = userRepository.save(
                 User.builder()
                         .email(email)
-                        .password(password)
+                        .password(encodedPassword)
                         .nickname(nickname)
                         .provider(User.Provider.LOCAL)
                         .status(User.Status.ACTIVE)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,20 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  # Redis
+  data:
+    redis:
+      repositories:
+        enabled: false
+    elasticsearch:
+      repositories:
+        enabled: false
+
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    password: ${REDIS_PASSWORD}
+
   #메일 의존성
   mail:
     host: smtp.gmail.com
@@ -30,3 +44,8 @@ spring:
 email:
   verification:
     url: ${EMAIL_VERIFICATION_URL}
+
+# JWT
+jwt:
+  secret: ${JWT_SECRET}
+  refresh_secret : ${JWT_REFRESH_SECRET}


### PR DESCRIPTION
## 📌 작업 개요
- 로그인api 및 기능 구현 (jwt + redis)

---

## ✨ 주요 변경 사항
- jjwt, 스프링시큐리티, redis, JPA, 캐시 의존성 추가
- jwt 기능 파일들 추가
- redis docker로 띄워서 사용
- 회원가입시 비밀번호 Bcrypt로 암호화하여 저장되는 것으로 수정
- 자체 로그인 api 구현

---

## 🖼️ 기능 살펴 보기
> 회원가입 시 db: 비밀번호 암호화하여 저장
<img width="2368" height="544" alt="image" src="https://github.com/user-attachments/assets/052f3a52-211d-4e32-8979-4c8f780f1f66" />

> 로그인 api
<img width="2044" height="1136" alt="image" src="https://github.com/user-attachments/assets/d8ca4d5a-b8d1-4e72-a8bc-cc120a18274e" />
- accessToken + refreshToken 발급해서 return
- 로그인 성공 시:
  - accessToken: 클라이언트에 즉시 응답
  - refreshToken: redis에 refresh:{userId} 형태로 7일간 저장

> 로그인 시 db last_login_at 업데이트
<img width="2108" height="278" alt="image" src="https://github.com/user-attachments/assets/c0622bfc-9f44-47a7-a7ff-e88121f771b3" />

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman local

---

## 💬 기타 참고 사항
- 예정 사항
  - 로그인 response에 salary 데이터 여부 추가 (분기처리)
  - 로그인 로직 예외처리 검토 및 추가
  - refresh token api

---

## 📎 관련 이슈 / 문서

