### PR TITLE
Feat/wish-r 위시리스트 조회 API 

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -3,6 +3,7 @@ package _team.earnedit.controller;
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
 import _team.earnedit.dto.wish.WishAddRequest;
 import _team.earnedit.dto.wish.WishAddResponse;
+import _team.earnedit.dto.wish.WishResponse;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,10 +12,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +33,18 @@ public class WishController {
         WishAddResponse response = wishService.addWish(wishAddRequest, userInfo.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("위시가 추가되었습니다.", response));
+    }
+
+    @GetMapping
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<List<WishResponse>>> getWishList(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+
+        List<WishResponse> wishList = wishService.getWishList(userInfo.getUserId());
+
+        return  ResponseEntity.ok(ApiResponse.success("위시 목록을 조회하였습니다.", wishList));
+
     }
 }

--- a/src/main/java/_team/earnedit/dto/wish/WishResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishResponse.java
@@ -1,0 +1,22 @@
+package _team.earnedit.dto.wish;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class WishResponse {
+    private Long id;
+    private Long userId;
+    private String name;
+    private int price;
+    private String itemImage;
+    private boolean isBought;
+    private String vendor;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private boolean isStarred;
+    private String url;
+}

--- a/src/main/java/_team/earnedit/dto/wish/WishResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishResponse.java
@@ -16,7 +16,5 @@ public class WishResponse {
     private boolean isBought;
     private String vendor;
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     private boolean isStarred;
-    private String url;
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     WISH_PRICE_INVALID(HttpStatus.BAD_REQUEST, "상품의 가격은 0 이상이어야 합니다."),
     WISH_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "상품 이미지는 반드시 있어야합니다."),
 
+    WISH_NOT_FOUND(HttpStatus.NO_CONTENT, "등록된 위시가 없습니다."),
+
 
     // 인증 Authentication
     AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),

--- a/src/main/java/_team/earnedit/global/exception/wish/WishException.java
+++ b/src/main/java/_team/earnedit/global/exception/wish/WishException.java
@@ -1,0 +1,18 @@
+package _team.earnedit.global.exception.wish;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+
+public class WishException extends CustomException {
+    private final ErrorCode errorCode;
+
+    public WishException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    public WishException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/_team/earnedit/repository/WishRepository.java
+++ b/src/main/java/_team/earnedit/repository/WishRepository.java
@@ -3,6 +3,8 @@ package _team.earnedit.repository;
 import _team.earnedit.entity.Wish;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WishRepository extends JpaRepository<Wish, Long> {
+import java.util.List;
 
+public interface WishRepository extends JpaRepository<Wish, Long> {
+    List<Wish> findByUserId(Long userId);
 }

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -2,15 +2,20 @@ package _team.earnedit.service;
 
 import _team.earnedit.dto.wish.WishAddRequest;
 import _team.earnedit.dto.wish.WishAddResponse;
+import _team.earnedit.dto.wish.WishResponse;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.exception.wish.WishException;
 import _team.earnedit.repository.UserRepository;
 import _team.earnedit.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Slf4j
@@ -19,6 +24,7 @@ public class WishService {
     private final WishRepository wishRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public WishAddResponse addWish(WishAddRequest wishAddRequest, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
@@ -38,5 +44,34 @@ public class WishService {
                 .wishId(wish.getId())
                 .createdAt(wish.getCreatedAt())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<WishResponse> getWishList(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        List<Wish> wishList = wishRepository.findByUserId(userId);
+
+        if (wishList.isEmpty()) {
+            throw new WishException(ErrorCode.WISH_NOT_FOUND);
+        }
+
+        return wishList.stream()
+                .map(wish -> WishResponse.builder()
+                        .id(wish.getId())
+                        .userId(wish.getUser().getId())
+                        .name(wish.getName())
+                        .price(wish.getPrice())
+                        .itemImage(wish.getItemImage())
+                        .isBought(wish.isBought())
+                        .vendor(wish.getVendor())
+                        .createdAt(wish.getCreatedAt())
+                        .updatedAt(wish.getUpdatedAt())
+                        .isStarred(wish.isStarred())
+                        .url(wish.getUrl())
+                        .build())
+                .toList();
+
     }
 }

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -67,9 +67,7 @@ public class WishService {
                         .isBought(wish.isBought())
                         .vendor(wish.getVendor())
                         .createdAt(wish.getCreatedAt())
-                        .updatedAt(wish.getUpdatedAt())
                         .isStarred(wish.isStarred())
-                        .url(wish.getUrl())
                         .build())
                 .toList();
 


### PR DESCRIPTION
## 📌 작업 개요
- 위시리스트 조회 API 추가

---

## ✨ 주요 변경 사항
-  위시리스트 조회 API 추가
- WishException 추가 
---

## 🖼️ 기능 살펴 보기
> <img width="1199" height="1037" alt="image" src="https://github.com/user-attachments/assets/0f435e15-af27-4974-ad57-4dab0698aba2" />
- 정상적으로 조회

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] Swagger UI

---

## 💬 기타 참고 사항
- 빠르게 기능 구현 초점으로 치고 있습니다
- 나중에 반드시 리팩토링 진행하겠지만, 문제 있는 부분은 그래도 지적 부탁드립니다~!
---

## 📎 관련 이슈 / 문서

