### PR TITLE
Feat/wish-u 위시 업데이트 API 

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +31,7 @@ public class WishController {
 
         WishAddResponse response = wishService.addWish(wishAddRequest, userInfo.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("위시가 추가되었습니다.", response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("위시가 추가되었습니다.", response));
     }
 
     @GetMapping

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -1,9 +1,7 @@
 package _team.earnedit.controller;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
-import _team.earnedit.dto.wish.WishAddRequest;
-import _team.earnedit.dto.wish.WishAddResponse;
-import _team.earnedit.dto.wish.WishResponse;
+import _team.earnedit.dto.wish.*;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,6 +43,21 @@ public class WishController {
         List<WishResponse> wishList = wishService.getWishList(userInfo.getUserId());
 
         return  ResponseEntity.ok(ApiResponse.success("위시 목록을 조회하였습니다.", wishList));
+
+    }
+
+
+    @PatchMapping("/{wishId}")
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<WishUpdateResponse>> updateWish(
+            @RequestBody @Valid WishUpdateRequest wishUpdateRequest,
+            @PathVariable Long wishId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        WishUpdateResponse response = wishService.updateWish(wishUpdateRequest, userInfo.getUserId(), wishId);
+
+        return ResponseEntity.ok(ApiResponse.success("위시가 수정되었습니다.", response));
 
     }
 }

--- a/src/main/java/_team/earnedit/dto/wish/WishUpdateRequest.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishUpdateRequest.java
@@ -1,12 +1,21 @@
 package _team.earnedit.dto.wish;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class WishUpdateRequest {
+
+    @NotBlank(message = "위시 이름은 공백값이 불가능합니다.")
     private String name;
+
     private String vendor;
-    private String itemImage;
+
+    @NotNull(message = "가격은 필수입니다.")
     private int price;
+
+    @NotBlank(message = "상품 이미지는 반드시 있어야합니다." )
+    private String itemImage;
     private String url;
 }

--- a/src/main/java/_team/earnedit/dto/wish/WishUpdateRequest.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishUpdateRequest.java
@@ -1,0 +1,12 @@
+package _team.earnedit.dto.wish;
+
+import lombok.Getter;
+
+@Getter
+public class WishUpdateRequest {
+    private String name;
+    private String vendor;
+    private String itemImage;
+    private int price;
+    private String url;
+}

--- a/src/main/java/_team/earnedit/dto/wish/WishUpdateResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishUpdateResponse.java
@@ -1,0 +1,21 @@
+package _team.earnedit.dto.wish;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class WishUpdateResponse {
+
+    private long wishId;
+    private String name;
+    private String vendor;
+    private int price;
+    private String ItemImage;
+    private String url;
+    private LocalDateTime updatedAt;
+
+
+}

--- a/src/main/java/_team/earnedit/entity/Wish.java
+++ b/src/main/java/_team/earnedit/entity/Wish.java
@@ -53,4 +53,13 @@ public class Wish {
     private boolean isStarred = false;
 
     private String url;
+
+
+    public void update(String name, int price, String itemImage, String vendor, String url) {
+        this.name = name;
+        this.price = price;
+        this.itemImage = itemImage;
+        this.vendor = vendor;
+        this.url = url;
+    }
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
     WISH_PRICE_INVALID(HttpStatus.BAD_REQUEST, "상품의 가격은 0 이상이어야 합니다."),
     WISH_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "상품 이미지는 반드시 있어야합니다."),
 
-    WISH_NOT_FOUND(HttpStatus.NO_CONTENT, "등록된 위시가 없습니다."),
+    WISHLIST_EMPTY(HttpStatus.NO_CONTENT, "등록된 위시가 없습니다."),
+    WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 위시입니다."),
 
 
     // 인증 Authentication

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -52,7 +52,7 @@ public class WishService {
         List<Wish> wishList = wishRepository.findByUserId(userId);
 
         if (wishList.isEmpty()) {
-            throw new WishException(ErrorCode.WISH_NOT_FOUND);
+            throw new WishException(ErrorCode.WISHLIST_EMPTY);
         }
 
         return wishList.stream()

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -1,8 +1,6 @@
 package _team.earnedit.service;
 
-import _team.earnedit.dto.wish.WishAddRequest;
-import _team.earnedit.dto.wish.WishAddResponse;
-import _team.earnedit.dto.wish.WishResponse;
+import _team.earnedit.dto.wish.*;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
@@ -71,5 +69,31 @@ public class WishService {
                         .build())
                 .toList();
 
+    }
+
+    @Transactional
+    public WishUpdateResponse updateWish(WishUpdateRequest wishUpdateRequest, Long userId, Long wishId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Wish wish = wishRepository.findById(wishId).orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+
+        wish.update(
+                wishUpdateRequest.getName(),
+                wishUpdateRequest.getPrice(),
+                wishUpdateRequest.getItemImage(),
+                wishUpdateRequest.getVendor(),
+                wishUpdateRequest.getUrl()
+        );
+
+        return WishUpdateResponse.builder()
+                .wishId(wish.getId())
+                .name(wish.getName())
+                .ItemImage(wish.getItemImage())
+                .vendor(wish.getVendor())
+                .price(wish.getPrice())
+                .url(wish.getUrl())
+                .updatedAt(wish.getUpdatedAt())
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 위시 업데이트 API 추가

---

## ✨ 주요 변경 사항
- 위시 업데이트 API 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1422" height="1421" alt="image" src="https://github.com/user-attachments/assets/93117e33-957c-46bf-91d4-56f4717d40e3" />
- 위시 업데이트 API 테스트 성공

> <img width="1417" height="1309" alt="image" src="https://github.com/user-attachments/assets/5c3b6e1b-d412-4e64-81c5-5259a5ee4e52" />
- 이름 필드 공백일 시 예외 응답 정상처리. 그밖에 예외도 동일

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] Swagger UI  

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

