### PR TITLE
Feat/wish-d 삭제 API 추가 

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -43,7 +43,7 @@ public class WishController {
 
         List<WishResponse> wishList = wishService.getWishList(userInfo.getUserId());
 
-        return  ResponseEntity.ok(ApiResponse.success("위시 목록을 조회하였습니다.", wishList));
+        return ResponseEntity.ok(ApiResponse.success("위시 목록을 조회하였습니다.", wishList));
 
     }
 
@@ -59,6 +59,19 @@ public class WishController {
         WishUpdateResponse response = wishService.updateWish(wishUpdateRequest, userInfo.getUserId(), wishId);
 
         return ResponseEntity.ok(ApiResponse.success("위시가 수정되었습니다.", response));
-
     }
+
+    @DeleteMapping("/{wishId}")
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<Long>> deleteWish(
+            @PathVariable Long wishId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo
+    ) {
+        wishService.deleteWish(wishId, userInfo.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("위시가 삭제되었습니다."));
+    }
+
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
 
     WISHLIST_EMPTY(HttpStatus.NO_CONTENT, "등록된 위시가 없습니다."),
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 위시입니다."),
+    WISH_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 수정 시도입니다."),
+    WISH_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 삭제 시도입니다."),
+
 
 
     // 인증 Authentication

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -78,6 +78,11 @@ public class WishService {
 
         Wish wish = wishRepository.findById(wishId).orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
 
+        // 다른 사용자의 수정 시도에 대한 예외처리
+        if (!wish.getUser().getId().equals(userId)) {
+            throw new WishException(ErrorCode.WISH_UPDATE_FORBIDDEN);
+        }
+
         wish.update(
                 wishUpdateRequest.getName(),
                 wishUpdateRequest.getPrice(),
@@ -95,5 +100,21 @@ public class WishService {
                 .url(wish.getUrl())
                 .updatedAt(wish.getUpdatedAt())
                 .build();
+    }
+
+    @Transactional
+    public void deleteWish(Long wishId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+
+        // 다른 사용자의 삭제 시도에 대한 예외처리
+        if (!wish.getUser().getId().equals(userId)) {
+            throw new WishException(ErrorCode.WISH_DELETE_FORBIDDEN);
+        }
+
+        wishRepository.delete(wish);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 삭제 API 추가

---

## ✨ 주요 변경 사항
- 삭제 API 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1426" height="1035" alt="image" src="https://github.com/user-attachments/assets/0bb3ee22-af21-4fd0-8ac4-c385d9e2cd24" />
- 삭제 성공

> <img width="1440" height="794" alt="image" src="https://github.com/user-attachments/assets/d95d1d8b-7dde-4d40-9d05-5fed2ad41045" />
- 이미 삭제된, 또는 존재하지 않는 위시 삭제 시도 시 예외 처리 

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] Swagger UI  
---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

