### PR TITLE
Feat/wish-read-1 위시 단일 조회 API 

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -47,6 +47,20 @@ public class WishController {
 
     }
 
+    @GetMapping("/{wishId}")
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<WishResponse>> getWish(
+            @PathVariable Long wishId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+
+        WishResponse wish = wishService.getWish(wishId, userInfo.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("위시를 조회하였습니다.", wish));
+
+    }
+
 
     @PatchMapping("/{wishId}")
     @Operation(

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -85,7 +85,7 @@ public class WishController {
     ) {
         wishService.deleteWish(wishId, userInfo.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("위시가 삭제되었습니다."));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success("위시가 삭제되었습니다."));
     }
 
 }

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -117,4 +117,27 @@ public class WishService {
 
         wishRepository.delete(wish);
     }
+
+    @Transactional(readOnly = true)
+    public WishResponse getWish(Long wishId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+
+        return WishResponse.builder()
+                .id(wish.getId())
+                .name(wish.getName())
+                .price(wish.getPrice())
+                .itemImage(wish.getItemImage())
+                .isBought(wish.isBought())
+                .vendor(wish.getVendor())
+                .createdAt(wish.getCreatedAt())
+                .updatedAt(wish.getUpdatedAt())
+                .isStarred(wish.isStarred())
+                .url(wish.getUrl())
+                .build();
+
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 위시 단일 조회 API 

---

## ✨ 주요 변경 사항
- 위시 단일 조회 API 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1464" height="992" alt="image" src="https://github.com/user-attachments/assets/bf7b2762-0839-48e8-ba89-ef7349cc35d0" />
- 성공 조회

> <img width="1535" height="1058" alt="image" src="https://github.com/user-attachments/assets/a6babf19-b403-48b0-a480-78211256697f" />
- 존재하지 않는 위시 조회 시도 시 예외



---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] Swagger UI 
---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

