### PR TITLE
Feat/social login : 카카오 로그인 api 구현

### DIFF
--- a/src/main/java/_team/earnedit/controller/AuthController.java
+++ b/src/main/java/_team/earnedit/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
             @RequestBody KakaoSignInRequestDto requestDto
     ) {
         SignInResponseDto responseDto = authService.signInWithKakao(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success("카카오 로그인이 완료되었습니다.", responseDto));
     }
 
@@ -50,7 +50,7 @@ public class AuthController {
             @RequestHeader("Authorization") String refreshToken
     ) {
         RefreshResponseDto responseDto = authService.refreshAccessToken(refreshToken);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success("카카오 로그인이 완료되었습니다.", responseDto));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("액세스 토큰 재생성과 리프레시 토큰 갱신이 완료되었습니다.", responseDto));
     }
 }

--- a/src/main/java/_team/earnedit/controller/AuthController.java
+++ b/src/main/java/_team/earnedit/controller/AuthController.java
@@ -1,6 +1,7 @@
 package _team.earnedit.controller;
 
 import _team.earnedit.dto.auth.*;
+import _team.earnedit.dto.socialLogin.KakaoSignInRequestDto;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.AuthService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,15 +19,28 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignUpResponseDto>> signup(@RequestBody @Valid SignUpRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<SignUpResponseDto>> signup(
+            @RequestBody @Valid SignUpRequestDto requestDto
+    ) {
         SignUpResponseDto responseDto = authService.signUp(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("회원가입이 완료되었습니다.", responseDto));
     }
 
     @PostMapping("/signin")
-    public ResponseEntity<ApiResponse<SignInResponseDto>> signIn(@RequestBody SignInRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<SignInResponseDto>> signIn(
+            @RequestBody SignInRequestDto requestDto
+    ) {
         SignInResponseDto responseDto = authService.signIn(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("로그인이 완료되었습니다.", responseDto));
+    }
+
+    @PostMapping("/signin/kakao")
+    public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithKakao(
+            @RequestBody KakaoSignInRequestDto requestDto
+    ) {
+        SignInResponseDto responseDto = authService.signInWithKakao(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("로그인이 완료되었습니다.", responseDto));
     }

--- a/src/main/java/_team/earnedit/controller/AuthController.java
+++ b/src/main/java/_team/earnedit/controller/AuthController.java
@@ -42,14 +42,15 @@ public class AuthController {
     ) {
         SignInResponseDto responseDto = authService.signInWithKakao(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success("로그인이 완료되었습니다.", responseDto));
+                .body(ApiResponse.success("카카오 로그인이 완료되었습니다.", responseDto));
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<RefreshResponseDto>> refreshToken(
             @RequestHeader("Authorization") String refreshToken
     ) {
-        RefreshResponseDto response = authService.refreshAccessToken(refreshToken);
-        return ResponseEntity.ok(ApiResponse.success("액세스 토큰 재생성과 리프레시 토큰 갱신이 완료되었습니다.", response));
+        RefreshResponseDto responseDto = authService.refreshAccessToken(refreshToken);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("카카오 로그인이 완료되었습니다.", responseDto));
     }
 }

--- a/src/main/java/_team/earnedit/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/SignUpRequestDto.java
@@ -14,9 +14,5 @@ public class SignUpRequestDto {
 
     private String password;
 
-    private Boolean isDarkMode;
-
-    private Boolean isPublic;
-
     private List<TermRequestDto> terms;
 }

--- a/src/main/java/_team/earnedit/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/SignUpRequestDto.java
@@ -14,11 +14,9 @@ public class SignUpRequestDto {
 
     private String password;
 
-    @Builder.Default
-    private Boolean isDarkMode = false;
+    private Boolean isDarkMode;
 
-    @Builder.Default
-    private Boolean isPublic = false;
+    private Boolean isPublic;
 
     private List<TermRequestDto> terms;
 }

--- a/src/main/java/_team/earnedit/dto/socialLogin/KakaoSignInRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/KakaoSignInRequestDto.java
@@ -1,0 +1,12 @@
+package _team.earnedit.dto.socialLogin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoSignInRequestDto {
+
+    private String accessToken;
+
+}

--- a/src/main/java/_team/earnedit/dto/socialLogin/KakaoUserInfoDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/KakaoUserInfoDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class KakaoUserInfoDto {
-    private Long id;
+    private String id;
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
 
@@ -25,5 +25,19 @@ public class KakaoUserInfoDto {
         private String nickname;
         @JsonProperty("profile_image_url")
         private String profileImageUrl;
+    }
+
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+    }
+
+    public String getNickname() {
+        return kakaoAccount != null && kakaoAccount.getProfile() != null
+                ? kakaoAccount.getProfile().getNickname() : null;
+    }
+
+    public String getProfileImage() {
+        return kakaoAccount != null && kakaoAccount.getProfile() != null
+                ? kakaoAccount.getProfile().getProfileImageUrl() : null;
     }
 }

--- a/src/main/java/_team/earnedit/dto/socialLogin/KakaoUserInfoDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/KakaoUserInfoDto.java
@@ -1,0 +1,29 @@
+package _team.earnedit.dto.socialLogin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private Profile profile;
+        private String email;
+        private String gender;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Profile {
+        private String nickname;
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -8,7 +8,10 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+)
 @Getter
 @Setter
 @Builder
@@ -55,6 +58,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Provider provider;
+
+    @Column
+    private String providerId;
 
     @Column(nullable = false)
     private Boolean isDarkMode = false;

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -21,7 +21,7 @@ public class User {
     }
 
     public enum Provider {
-        LOCAL, SOCIAL
+        LOCAL, KAKAO, APPLE
     }
 
     @Id

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -62,9 +62,11 @@ public class User {
     @Column
     private String providerId;
 
+    @Builder.Default
     @Column(nullable = false)
     private Boolean isDarkMode = false;
 
+    @Builder.Default
     @Column(nullable = false)
     private Boolean isPublic = false;
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -24,6 +24,9 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레쉬 토큰을 찾을 수 없습니다."),
 
+    // OAuth
+    INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
+
     // 이메일 인증
     EMAIL_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(User.Provider provider, String providerId);
+
 }

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -55,8 +55,6 @@ public class AuthService {
                         .nickname(nickname)
                         .provider(User.Provider.LOCAL)
                         .status(User.Status.ACTIVE)
-                        .isDarkMode(false)
-                        .isPublic(false)
                         .build()
         );
 

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -102,6 +102,9 @@ public class AuthService {
         // 이메일이 없는 경우
         String safeEmail = (email != null) ? email : "kakao_" + kakaoId + "@kakao-user.com";
 
+        // 닉네임이 없는 경우
+        String safeNickname = (nickname != null) ? nickname : generateUniqueNickname();;
+
         Optional<User> optionalUser = userRepository.findByProviderAndProviderId(
                 User.Provider.KAKAO, kakaoId
         );
@@ -117,7 +120,7 @@ public class AuthService {
                 .provider(User.Provider.KAKAO)
                 .providerId(kakaoId)
                 .email(safeEmail)
-                .nickname(nickname)
+                .nickname(safeNickname)
                 .profileImage(profileImage)
                 .status(User.Status.ACTIVE)
                 .build()));

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -96,14 +96,11 @@ public class AuthService {
 
         String kakaoId = kakaoUserInfo.getId();
         String email = kakaoUserInfo.getEmail();
-        String nickname = kakaoUserInfo.getNickname();
+        String nickname = generateUniqueNickname();
         String profileImage = kakaoUserInfo.getProfileImage();
 
         // 이메일이 없는 경우
         String safeEmail = (email != null) ? email : "kakao_" + kakaoId + "@kakao-user.com";
-
-        // 닉네임이 없는 경우
-        String safeNickname = (nickname != null) ? nickname : generateUniqueNickname();;
 
         Optional<User> optionalUser = userRepository.findByProviderAndProviderId(
                 User.Provider.KAKAO, kakaoId
@@ -120,7 +117,7 @@ public class AuthService {
                 .provider(User.Provider.KAKAO)
                 .providerId(kakaoId)
                 .email(safeEmail)
-                .nickname(safeNickname)
+                .nickname(nickname)
                 .profileImage(profileImage)
                 .status(User.Status.ACTIVE)
                 .build()));

--- a/src/main/java/_team/earnedit/service/socialLogin/KakaoOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/KakaoOAuthService.java
@@ -1,0 +1,4 @@
+package _team.earnedit.service.socialLogin;
+
+public class KakaoOAuthService {
+}

--- a/src/main/java/_team/earnedit/service/socialLogin/KakaoOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/KakaoOAuthService.java
@@ -1,4 +1,38 @@
 package _team.earnedit.service.socialLogin;
 
+import _team.earnedit.dto.socialLogin.KakaoUserInfoDto;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
 public class KakaoOAuthService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public KakaoUserInfoDto getUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.GET,
+                    entity,
+                    KakaoUserInfoDto.class
+            );
+
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 카카오 로그인 api 구현

---

## ✨ 주요 변경 사항
- KakaoOAuthService 파일 생성
  - 카카오 토큰에서 user info추출코드 구현
- signInWithKakao 서비스메서드 & 컨트롤러 메서드 구현
  - email이 토큰에서 추출되지 않을 경우 kakaoId를 이용하여 생성해서 넣어줍니다
  - 닉네임이 토큰에서 추출되지 않을 경우 다른 유저들과 똑같이 닉네임랜덤(but unique)생성으로 넣어줍니다

---

## 🖼️ 기능 살펴 보기
> FE에서 발급받은 kakao token으로 api 테스트
<img width="1766" height="1280" alt="image" src="https://github.com/user-attachments/assets/b46ab258-13f4-44a3-b12b-9c922da63b28" />

> DB에 잘 저장된 모습
<img width="3386" height="220" alt="image" src="https://github.com/user-attachments/assets/513630f3-07e9-461d-8cb1-3fd6a6a69b60" />


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman

---

## 💬 기타 참고 사항
- 소셜로그인 약관 관련 회의필요

---

## 📎 관련 이슈 / 문서
