### PR TITLE
Feat/wish-read-1 Wish 단일 조회 API 추가

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -71,7 +71,7 @@ public class WishController {
     ) {
         wishService.deleteWish(wishId, userInfo.getUserId());
 
-        return ResponseEntity.ok(ApiResponse.success("위시가 삭제되었습니다."));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success("위시가 삭제되었습니다."));
     }
 
 }

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -38,12 +38,26 @@ public class WishController {
     @Operation(
             security = {@SecurityRequirement(name = "bearer-key")}
     )
-    public ResponseEntity<ApiResponse<List<WishResponse>>> getWishList(
+    public ResponseEntity<ApiResponse<List<WishListResponse>>> getWishList(
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
 
-        List<WishResponse> wishList = wishService.getWishList(userInfo.getUserId());
+        List<WishListResponse> wishList = wishService.getWishList(userInfo.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("위시 목록을 조회하였습니다.", wishList));
+
+    }
+
+    @GetMapping("/{wishId}")
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<WishDetailResponse>> getWish(
+            @PathVariable Long wishId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+
+        WishDetailResponse wish = wishService.getWish(wishId, userInfo.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("위시를 조회하였습니다.", wish));
 
     }
 

--- a/src/main/java/_team/earnedit/dto/wish/WishDetailResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishDetailResponse.java
@@ -1,0 +1,22 @@
+package _team.earnedit.dto.wish;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class WishDetailResponse {
+    private Long id;
+    private Long userId;
+    private String name;
+    private int price;
+    private String itemImage;
+    private boolean isBought;
+    private String vendor;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String url;
+    private boolean isStarred;
+}

--- a/src/main/java/_team/earnedit/dto/wish/WishListResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishListResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 @Builder
 @Getter
-public class WishResponse {
+public class WishListResponse {
     private Long id;
     private Long userId;
     private String name;

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -45,7 +45,7 @@ public class WishService {
     }
 
     @Transactional(readOnly = true)
-    public List<WishResponse> getWishList(Long userId) {
+    public List<WishListResponse> getWishList(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
@@ -56,7 +56,7 @@ public class WishService {
         }
 
         return wishList.stream()
-                .map(wish -> WishResponse.builder()
+                .map(wish -> WishListResponse.builder()
                         .id(wish.getId())
                         .userId(wish.getUser().getId())
                         .name(wish.getName())
@@ -116,5 +116,28 @@ public class WishService {
         }
 
         wishRepository.delete(wish);
+    }
+
+    @Transactional(readOnly = true)
+    public WishDetailResponse getWish(Long wishId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+
+        return WishDetailResponse.builder()
+                .id(wish.getId())
+                .name(wish.getName())
+                .price(wish.getPrice())
+                .itemImage(wish.getItemImage())
+                .isBought(wish.isBought())
+                .vendor(wish.getVendor())
+                .createdAt(wish.getCreatedAt())
+                .updatedAt(wish.getUpdatedAt())
+                .isStarred(wish.isStarred())
+                .url(wish.getUrl())
+                .build();
+
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 이전에 pr 병합되었던 위시 단일 조회 버그를 수정 후 재 PR

---

## ✨ 주요 변경 사항
- DTO 객체를 각 컨트롤러에 맞게 수정 및 추가하였습니다

---

## 🖼️ 기능 살펴 보기
> <img width="1492" height="1222" alt="image" src="https://github.com/user-attachments/assets/13953a7b-121d-43eb-9678-c9180f9c7579" />
- 정상 조회 성공

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] Swagger UI 

---

## 💬 기타 참고 사항
- 금요일에 작업할 때 수정해야지 했던 부분인데.. 수정하지 않고 PR을 날렸던 저의 실수입니다 허.. 잘 확인하고 올리겠습니다

---

## 📎 관련 이슈 / 문서

