### PR TITLE
Feat/star Star 상태 업데이트 API, 조회 API 구현

### DIFF
--- a/src/main/java/_team/earnedit/controller/StarController.java
+++ b/src/main/java/_team/earnedit/controller/StarController.java
@@ -1,0 +1,35 @@
+package _team.earnedit.controller;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.global.ApiResponse;
+import _team.earnedit.service.StarService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/star")
+@RequiredArgsConstructor
+public class StarController {
+
+    private final StarService starService;
+
+    @PatchMapping("/{wishId}")
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<String>> updateStar(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable long wishId) {
+        starService.updateStar(userInfo.getUserId(), wishId);
+
+        return ResponseEntity.ok(ApiResponse.success("Star에 해당 위시를 추가하였습니다."));
+    }
+
+}

--- a/src/main/java/_team/earnedit/controller/StarController.java
+++ b/src/main/java/_team/earnedit/controller/StarController.java
@@ -1,17 +1,18 @@
 package _team.earnedit.controller;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.dto.wish.WishListResponse;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.StarService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/star")
@@ -24,12 +25,24 @@ public class StarController {
     @Operation(
             security = {@SecurityRequirement(name = "bearer-key")}
     )
-    public ResponseEntity<ApiResponse<String>> updateStar(
+    public ResponseEntity<ApiResponse<Boolean>> updateStar(
             @AuthenticationPrincipal JwtUserInfoDto userInfo,
             @PathVariable long wishId) {
-        starService.updateStar(userInfo.getUserId(), wishId);
+        boolean isStar = starService.updateStar(userInfo.getUserId(), wishId);
 
-        return ResponseEntity.ok(ApiResponse.success("Star에 해당 위시를 추가하였습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(String.format("Star 상태를 변경했습니다. %s", isStar)));
+    }
+
+    @GetMapping
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<List<WishListResponse>>> getStarsWish(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo
+    ) {
+        List<WishListResponse> starsWish = starService.getStarsWish(userInfo.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("Star 목록을 조회했습니다.", starsWish));
     }
 
 }

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -22,9 +22,7 @@ public class WishController {
     private final WishService wishService;
 
     @PostMapping
-    @Operation(
-            security = {@SecurityRequirement(name = "bearer-key")}
-    )
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<ApiResponse<WishAddResponse>> addWish(
             @RequestBody @Valid WishAddRequest wishAddRequest,
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
@@ -35,9 +33,7 @@ public class WishController {
     }
 
     @GetMapping
-    @Operation(
-            security = {@SecurityRequirement(name = "bearer-key")}
-    )
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<ApiResponse<List<WishListResponse>>> getWishList(
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
 
@@ -48,9 +44,7 @@ public class WishController {
     }
 
     @GetMapping("/{wishId}")
-    @Operation(
-            security = {@SecurityRequirement(name = "bearer-key")}
-    )
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<ApiResponse<WishDetailResponse>> getWish(
             @PathVariable Long wishId,
             @AuthenticationPrincipal JwtUserInfoDto userInfo) {
@@ -63,9 +57,7 @@ public class WishController {
 
 
     @PatchMapping("/{wishId}")
-    @Operation(
-            security = {@SecurityRequirement(name = "bearer-key")}
-    )
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<ApiResponse<WishUpdateResponse>> updateWish(
             @RequestBody @Valid WishUpdateRequest wishUpdateRequest,
             @PathVariable Long wishId,
@@ -76,16 +68,22 @@ public class WishController {
     }
 
     @DeleteMapping("/{wishId}")
-    @Operation(
-            security = {@SecurityRequirement(name = "bearer-key")}
-    )
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<ApiResponse<Long>> deleteWish(
             @PathVariable Long wishId,
-            @AuthenticationPrincipal JwtUserInfoDto userInfo
-    ) {
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
         wishService.deleteWish(wishId, userInfo.getUserId());
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success("위시가 삭제되었습니다."));
+    }
+
+    @PatchMapping("/{wishId}/toggle-bought")
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")})
+    public ResponseEntity<ApiResponse<String>> toggleBought(
+            @PathVariable Long wishId,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        boolean isBought = wishService.toggleBoughtStatus(wishId, userInfo.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(String.format("구매상태가 변경되었습니다 %s", isBought)));
     }
 
 }

--- a/src/main/java/_team/earnedit/dto/wish/WishListResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishListResponse.java
@@ -1,5 +1,6 @@
 package _team.earnedit.dto.wish;
 
+import _team.earnedit.entity.Wish;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,4 +18,19 @@ public class WishListResponse {
     private String vendor;
     private LocalDateTime createdAt;
     private boolean isStarred;
+
+
+    public static WishListResponse from(Wish wish) {
+        return WishListResponse.builder()
+                .id(wish.getId())
+                .userId(wish.getUser().getId())
+                .name(wish.getName())
+                .price(wish.getPrice())
+                .itemImage(wish.getItemImage())
+                .isBought(wish.isBought())
+                .vendor(wish.getVendor())
+                .createdAt(wish.getCreatedAt())
+                .isStarred(wish.isStarred())
+                .build();
+    }
 }

--- a/src/main/java/_team/earnedit/entity/Star.java
+++ b/src/main/java/_team/earnedit/entity/Star.java
@@ -1,0 +1,30 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.boot.model.naming.Identifier;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Star {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wish_id", nullable = false)
+    private Wish wish;
+
+    private int rank;
+}

--- a/src/main/java/_team/earnedit/entity/Star.java
+++ b/src/main/java/_team/earnedit/entity/Star.java
@@ -1,10 +1,7 @@
 package _team.earnedit.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.boot.model.naming.Identifier;
 
 @Builder
@@ -26,5 +23,6 @@ public class Star {
     @JoinColumn(name = "wish_id", nullable = false)
     private Wish wish;
 
+    @Setter
     private int rank;
 }

--- a/src/main/java/_team/earnedit/entity/Wish.java
+++ b/src/main/java/_team/earnedit/entity/Wish.java
@@ -63,8 +63,14 @@ public class Wish {
         this.url = url;
     }
 
-    // Star 상태 토글
+    // Star 상태
     public void setStarred(boolean starred) {
         this.isStarred =  starred;
     }
+
+    // Bought 상태
+    public void setBought(boolean bought) {
+        this.isBought =  bought;
+    }
+
 }

--- a/src/main/java/_team/earnedit/entity/Wish.java
+++ b/src/main/java/_team/earnedit/entity/Wish.java
@@ -62,4 +62,9 @@ public class Wish {
         this.vendor = vendor;
         this.url = url;
     }
+
+    // Star 상태 토글
+    public void setStarred(boolean starred) {
+        this.isStarred =  starred;
+    }
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
     WISH_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 수정 시도입니다."),
     WISH_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 삭제 시도입니다."),
 
+    // Star
+    TOP_WISH_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "Star는 5개를 초과할 수 없습니다."),
 
 
     // 인증 Authentication

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
     // Star
     TOP_WISH_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "Star는 5개를 초과할 수 없습니다."),
+    TOP_WISH_EMPTY(HttpStatus.NOT_FOUND, "조회된 Star가 없습니다."),
 
 
     // 인증 Authentication

--- a/src/main/java/_team/earnedit/global/exception/star/StarException.java
+++ b/src/main/java/_team/earnedit/global/exception/star/StarException.java
@@ -1,0 +1,18 @@
+package _team.earnedit.global.exception.star;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+
+public class StarException extends CustomException {
+    private final ErrorCode errorCode;
+
+    public StarException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    public StarException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/_team/earnedit/repository/StarRepository.java
+++ b/src/main/java/_team/earnedit/repository/StarRepository.java
@@ -3,5 +3,13 @@ package _team.earnedit.repository;
 import _team.earnedit.entity.Star;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StarRepository extends JpaRepository<Star, Long> {
+
+    int countByUserId(long userId);
+
+    void deleteByUserIdAndWishId(Long userId, Long wishId);
+
+    List<Star> findByUserIdOrderByRankAsc(Long userId);
 }

--- a/src/main/java/_team/earnedit/repository/StarRepository.java
+++ b/src/main/java/_team/earnedit/repository/StarRepository.java
@@ -1,0 +1,7 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.Star;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StarRepository extends JpaRepository<Star, Long> {
+}

--- a/src/main/java/_team/earnedit/repository/WishRepository.java
+++ b/src/main/java/_team/earnedit/repository/WishRepository.java
@@ -1,10 +1,16 @@
 package _team.earnedit.repository;
 
 import _team.earnedit.entity.Wish;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.NativeQuery;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
     List<Wish> findByUserId(Long userId);
+
+    @Query("SELECT COUNT(w) FROM Wish w WHERE w.user.id = :userId AND w.isStarred = true")
+    int countStarredByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -1,5 +1,7 @@
 package _team.earnedit.service;
 
+import _team.earnedit.dto.wish.WishListResponse;
+import _team.earnedit.entity.Star;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
@@ -14,6 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -24,26 +29,64 @@ public class StarService {
 
 
     @Transactional
-    public void updateStar(Long userId, long wishId) {
+    public boolean updateStar(Long userId, long wishId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
         Wish wish = wishRepository.findById(wishId)
                 .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
 
-
         boolean isStarred = wish.isStarred();
 
         if (!isStarred) {
-            // 추가 시 검증
-            int currentStarCount = wishRepository.countStarredByUserId(userId);
+            // Star 추가 시 검증
+            int currentStarCount = starRepository.countByUserId(userId);
             if (currentStarCount >= 5) {
                 throw new StarException(ErrorCode.TOP_WISH_LIMIT_EXCEEDED);
             }
+
+            // Star 순위는 현재 별표 개수 + 1
+            Star star = Star.builder()
+                    .user(user)
+                    .wish(wish)
+                    .rank(currentStarCount + 1)
+                    .build();
+
+            starRepository.save(star);
             wish.setStarred(true);
+            return true;
         } else {
-            // 제거는 자유
+            // Star 제거
+            starRepository.deleteByUserIdAndWishId(userId, wishId);
             wish.setStarred(false);
+
+            // Stra 삭제된 이후의 rank 재정렬
+            List<Star> stars = starRepository.findByUserIdOrderByRankAsc(userId);
+            for (int i = 0; i < stars.size(); i++) {
+                stars.get(i).setRank(i + 1); // 순위 재정렬
+            }
+            return false;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<WishListResponse> getStarsWish(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        // 정렬된 순서로
+        List<Star> stars = starRepository.findByUserIdOrderByRankAsc(userId);
+
+        // 조회된 Star가 없을 때
+        if (stars.isEmpty()) {
+            throw new StarException(ErrorCode.TOP_WISH_EMPTY);
+        }
+
+        return stars.stream()
+                .map(star -> {
+                    Wish wish = star.getWish();
+                    return WishListResponse.from(wish);  // 또는 WishListResponse 생성자 활용
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -1,0 +1,49 @@
+package _team.earnedit.service;
+
+import _team.earnedit.entity.User;
+import _team.earnedit.entity.Wish;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.star.StarException;
+import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.exception.wish.WishException;
+import _team.earnedit.repository.StarRepository;
+import _team.earnedit.repository.UserRepository;
+import _team.earnedit.repository.WishRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StarService {
+    private final StarRepository starRepository;
+    private final WishRepository wishRepository;
+    private final UserRepository userRepository;
+
+
+    @Transactional
+    public void updateStar(Long userId, long wishId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+
+
+        boolean isStarred = wish.isStarred();
+
+        if (!isStarred) {
+            // 추가 시 검증
+            int currentStarCount = wishRepository.countStarredByUserId(userId);
+            if (currentStarCount >= 5) {
+                throw new StarException(ErrorCode.TOP_WISH_LIMIT_EXCEEDED);
+            }
+            wish.setStarred(true);
+        } else {
+            // 제거는 자유
+            wish.setStarred(false);
+        }
+    }
+}

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -140,4 +140,17 @@ public class WishService {
                 .build();
 
     }
+
+    @Transactional
+    public boolean toggleBoughtStatus(Long wishId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+
+        wish.setBought(!wish.isBought());
+
+        return wish.isBought();
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- Star 상태 업데이트 및 조회 API, 구매상태 업데이트 API 구현했습니다.

---

## ✨ 주요 변경 사항
- Star 엔티티 추가
- Star 추가/삭제 (업데이트), 조회 API  추가
- 구매상태 업데이트 API 구현

---

## 🖼️ 기능 살펴 보기
> <img width="1426" height="859" alt="image" src="https://github.com/user-attachments/assets/d155aa74-2e8a-48d7-bfc8-9a87b0355605" />
- Wish의 Star 상태 변경 성공 

> <img width="1432" height="1021" alt="image" src="https://github.com/user-attachments/assets/3a89d835-f1a0-471d-8b99-715a3343cabe" />
- 유저의 Star 목록 조회

> <img width="1451" height="1097" alt="image" src="https://github.com/user-attachments/assets/7c77467d-8f59-4ab0-b093-155be39b7150" />
- Star 5개 초과 시 예외

> <img width="1400" height="938" alt="image" src="https://github.com/user-attachments/assets/58cb7310-53ea-4e86-9e15-3df12a1e2bbc" />
- 유저 Star 목록 조회 시 [] 값 예외 처리

> <img width="1446" height="790" alt="image" src="https://github.com/user-attachments/assets/9a69dfb5-2e9f-4c93-8310-f8422c1cb6b1" />
- 구매상태 업데이트 API 호출



> <img width="1428" height="991" alt="image" src="https://github.com/user-attachments/assets/3f184bb8-3bfe-4021-ae6b-ae507e4933c1" />
- 구매상태 true 업데이트


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생
- [x] Swagger UI
---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

