### PR TITLE
Feat/social apple : 애플 소셜로그인(회원가입) api 구현 (+ redis로 공개키 관리)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 	// jjwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// apple 로그인
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.37'

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// apple 로그인
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// 시큐리티
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/_team/earnedit/controller/AuthController.java
+++ b/src/main/java/_team/earnedit/controller/AuthController.java
@@ -2,6 +2,7 @@ package _team.earnedit.controller;
 
 import _team.earnedit.dto.auth.*;
 import _team.earnedit.dto.socialLogin.KakaoSignInRequestDto;
+import _team.earnedit.dto.socialLogin.AppleSignInRequestDto;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.AuthService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -43,6 +44,15 @@ public class AuthController {
         SignInResponseDto responseDto = authService.signInWithKakao(requestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success("카카오 로그인이 완료되었습니다.", responseDto));
+    }
+
+    @PostMapping("/signin/apple")
+    public ResponseEntity<ApiResponse<SignInResponseDto>> signInWithApple(
+            @RequestBody AppleSignInRequestDto requestDto
+    ) {
+        SignInResponseDto response = authService.signInWithApple(requestDto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("애플 로그인이 완료되었습니다.", response));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/_team/earnedit/dto/socialLogin/AppleSignInRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/AppleSignInRequestDto.java
@@ -1,0 +1,12 @@
+package _team.earnedit.dto.socialLogin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AppleSignInRequestDto {
+
+    private String idToken;
+
+}

--- a/src/main/java/_team/earnedit/dto/socialLogin/AppleUserInfoDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/AppleUserInfoDto.java
@@ -1,0 +1,13 @@
+package _team.earnedit.dto.socialLogin;
+
+import lombok.Getter;
+
+@Getter
+public class AppleUserInfoDto {
+    private final String email;
+
+    public AppleUserInfoDto(String email) {
+        this.email = email;
+    }
+
+}

--- a/src/main/java/_team/earnedit/dto/socialLogin/AppleUserInfoDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/AppleUserInfoDto.java
@@ -1,13 +1,16 @@
 package _team.earnedit.dto.socialLogin;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class AppleUserInfoDto {
-    private final String email;
 
-    public AppleUserInfoDto(String email) {
-        this.email = email;
-    }
+    private String email;
+
+    private String sub; // providerId
 
 }

--- a/src/main/java/_team/earnedit/dto/socialLogin/KakaoUserInfoDto.java
+++ b/src/main/java/_team/earnedit/dto/socialLogin/KakaoUserInfoDto.java
@@ -22,7 +22,7 @@ public class KakaoUserInfoDto {
     @Getter
     @NoArgsConstructor
     public static class Profile {
-        private String nickname;
+//        private String nickname;
         @JsonProperty("profile_image_url")
         private String profileImageUrl;
     }
@@ -31,10 +31,12 @@ public class KakaoUserInfoDto {
         return kakaoAccount != null ? kakaoAccount.getEmail() : null;
     }
 
+    /*
     public String getNickname() {
         return kakaoAccount != null && kakaoAccount.getProfile() != null
                 ? kakaoAccount.getProfile().getNickname() : null;
     }
+     */
 
     public String getProfileImage() {
         return kakaoAccount != null && kakaoAccount.getProfile() != null

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -39,6 +39,9 @@ public enum ErrorCode {
 
     // OAuth
     INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 소셜 인증 토큰입니다."),
+    APPLE_PUBLIC_KEY_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Apple 공개 키를 찾을 수 없습니다."),
+    APPLE_ID_TOKEN_PARSING_ERROR(HttpStatus.UNAUTHORIZED, "Apple idToken 파싱 중 오류가 발생했습니다."),
 
     // 이메일 인증
     EMAIL_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/java/_team/earnedit/global/exception/OAuth/OAuthException.java
+++ b/src/main/java/_team/earnedit/global/exception/OAuth/OAuthException.java
@@ -1,0 +1,21 @@
+package _team.earnedit.global.exception.OAuth;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class OAuthException extends CustomException {
+
+  private final ErrorCode errorCode;
+
+  public OAuthException(ErrorCode errorCode) {
+    super(errorCode);
+    this.errorCode = errorCode;
+  }
+
+  public OAuthException(ErrorCode errorCode, String customMessage) {
+    super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/_team/earnedit/global/jwt/ExternalJwtUtil.java
+++ b/src/main/java/_team/earnedit/global/jwt/ExternalJwtUtil.java
@@ -1,4 +1,27 @@
 package _team.earnedit.global.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.jackson.io.JacksonDeserializer;
+
+import java.security.PublicKey;
+import java.util.Date;
+
 public class ExternalJwtUtil {
+
+    // 공개키 기반 JWT 파싱
+    public static Claims parse(String token, PublicKey publicKey) {
+        return Jwts.parserBuilder()
+                .deserializeJsonWith(new JacksonDeserializer<>())
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 만료 여부 확인
+    public static boolean isExpired(Claims claims) {
+        Date expiration = claims.getExpiration();
+        return expiration != null && expiration.before(new Date());
+    }
 }

--- a/src/main/java/_team/earnedit/global/jwt/ExternalJwtUtil.java
+++ b/src/main/java/_team/earnedit/global/jwt/ExternalJwtUtil.java
@@ -1,0 +1,4 @@
+package _team.earnedit.global.jwt;
+
+public class ExternalJwtUtil {
+}

--- a/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
@@ -1,9 +1,93 @@
 package _team.earnedit.service.socialLogin;
 
+import _team.earnedit.dto.socialLogin.AppleUserInfoDto;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.OAuth.OAuthException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.jackson.io.JacksonDeserializer;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+import java.math.BigInteger;
+import java.net.URL;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
 @RequiredArgsConstructor
 public class AppleOAuthService {
+
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AppleUserInfoDto getUserInfo(String idToken) {
+        try {
+            // idToken Header 에서 kid, alg 추출
+            String[] tokenParts = idToken.split("\\.");
+            String headerJson = new String(Base64.getUrlDecoder().decode(tokenParts[0]));
+            JsonNode header = objectMapper.readTree(headerJson);
+
+            String kid = header.get("kid").asText();
+            String alg = header.get("alg").asText();
+
+            // Apple 공개 키 목록 불러와 매칭되는 키 찾기
+            JsonNode publicKeys = objectMapper.readTree(new URL(APPLE_PUBLIC_KEYS_URL));
+
+            JsonNode matchedKey = null;
+            for (JsonNode key : publicKeys.get("keys")) {
+                if (key.get("kid").asText().equals(kid) && key.get("alg").asText().equals(alg)) {
+                    matchedKey = key;
+                    break;
+                }
+            }
+
+            if (matchedKey == null) {
+                throw new OAuthException(ErrorCode.APPLE_PUBLIC_KEY_NOT_FOUND);
+            }
+
+            // 공개 키 생성
+            byte[] modulusBytes = Base64.getUrlDecoder().decode(matchedKey.get("n").asText());
+            byte[] exponentBytes = Base64.getUrlDecoder().decode(matchedKey.get("e").asText());
+
+            RSAPublicKeySpec keySpec = new RSAPublicKeySpec(
+                    new BigInteger(1, modulusBytes),
+                    new BigInteger(1, exponentBytes)
+            );
+            PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(keySpec);
+
+            // idToken 검증 + 파싱
+            Claims claims = Jwts.parserBuilder()
+                    .deserializeJsonWith(new JacksonDeserializer<>())
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(idToken)
+                    .getBody();
+
+            Date expiration = claims.getExpiration();
+            if (expiration != null && expiration.before(new Date())) {
+                throw new OAuthException(ErrorCode.TOKEN_EXPIRED);
+            }
+
+            String email = (String) claims.get("email");
+            String sub = claims.getSubject();
+
+            AppleUserInfoDto dto = new AppleUserInfoDto();
+            dto.setEmail(email);
+            dto.setSub(sub);
+            return dto;
+
+        } catch (SignatureException e) {
+            throw new OAuthException(ErrorCode.INVALID_OAUTH_TOKEN);
+        } catch (Exception e) {
+            throw new OAuthException(ErrorCode.APPLE_ID_TOKEN_PARSING_ERROR);
+        }
+    }
 }

--- a/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
@@ -1,0 +1,9 @@
+package _team.earnedit.service.socialLogin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppleOAuthService {
+}

--- a/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
@@ -7,8 +7,6 @@ import _team.earnedit.global.jwt.ExternalJwtUtil;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.jackson.io.JacksonDeserializer;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -22,7 +20,6 @@ import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.Date;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/AppleOAuthService.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.math.BigInteger;
@@ -17,6 +18,8 @@ import java.net.URL;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
 
@@ -27,6 +30,7 @@ public class AppleOAuthService {
     private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RedisTemplate<String, String> redisTemplate;
 
     public AppleUserInfoDto getUserInfo(String idToken) {
         try {
@@ -54,14 +58,7 @@ public class AppleOAuthService {
             }
 
             // 공개 키 생성
-            byte[] modulusBytes = Base64.getUrlDecoder().decode(matchedKey.get("n").asText());
-            byte[] exponentBytes = Base64.getUrlDecoder().decode(matchedKey.get("e").asText());
-
-            RSAPublicKeySpec keySpec = new RSAPublicKeySpec(
-                    new BigInteger(1, modulusBytes),
-                    new BigInteger(1, exponentBytes)
-            );
-            PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(keySpec);
+            PublicKey publicKey = getApplePublicKeyFromRedisOrFetch(kid, alg);
 
             // idToken 검증 + 파싱
             Claims claims = Jwts.parserBuilder()
@@ -88,6 +85,44 @@ public class AppleOAuthService {
             throw new OAuthException(ErrorCode.INVALID_OAUTH_TOKEN);
         } catch (Exception e) {
             throw new OAuthException(ErrorCode.APPLE_ID_TOKEN_PARSING_ERROR);
+        }
+    }
+
+    private PublicKey getApplePublicKeyFromRedisOrFetch(String kid, String alg) {
+        try {
+            String redisKey = "oauth:apple:key:" + kid + ":" + alg;
+
+            // Redis에서 공개키 가져오기
+            String encodedKey = redisTemplate.opsForValue().get(redisKey);
+            if (encodedKey != null) {
+                byte[] decoded = Base64.getDecoder().decode(encodedKey);
+                return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(decoded));
+            }
+
+            // 없으면 Apple 서버에서 가져오기
+            JsonNode keys = objectMapper.readTree(new URL(APPLE_PUBLIC_KEYS_URL));
+            for (JsonNode key : keys.get("keys")) {
+                if (key.get("kid").asText().equals(kid) && key.get("alg").asText().equals(alg)) {
+                    byte[] modulusBytes = Base64.getUrlDecoder().decode(key.get("n").asText());
+                    byte[] exponentBytes = Base64.getUrlDecoder().decode(key.get("e").asText());
+
+                    RSAPublicKeySpec keySpec = new RSAPublicKeySpec(
+                            new BigInteger(1, modulusBytes),
+                            new BigInteger(1, exponentBytes)
+                    );
+                    PublicKey pubKey = KeyFactory.getInstance("RSA").generatePublic(keySpec);
+
+                    // Base64 인코딩 후 Redis 저장 (12시간)
+                    String encoded = Base64.getEncoder().encodeToString(pubKey.getEncoded());
+                    redisTemplate.opsForValue().set(redisKey, encoded, Duration.ofHours(12));
+
+                    return pubKey;
+                }
+            }
+
+            throw new OAuthException(ErrorCode.APPLE_PUBLIC_KEY_NOT_FOUND);
+        } catch (Exception e) {
+            throw new OAuthException(ErrorCode.APPLE_PUBLIC_KEY_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/_team/earnedit/service/socialLogin/KakaoOAuthService.java
+++ b/src/main/java/_team/earnedit/service/socialLogin/KakaoOAuthService.java
@@ -2,7 +2,7 @@ package _team.earnedit.service.socialLogin;
 
 import _team.earnedit.dto.socialLogin.KakaoUserInfoDto;
 import _team.earnedit.global.ErrorCode;
-import _team.earnedit.global.exception.CustomException;
+import _team.earnedit.global.exception.OAuth.OAuthException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -31,7 +31,7 @@ public class KakaoOAuthService {
 
             return response.getBody();
         } catch (HttpClientErrorException e) {
-            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+            throw new OAuthException(ErrorCode.INVALID_OAUTH_TOKEN);
         }
 
     }


### PR DESCRIPTION
## 📌 작업 개요
- 애플 소셜로그인(회원가입) api 구현 (+ redis로 공개키 관리)

---

## ✨ 주요 변경 사항

- build.gradle 에 필요 의존성 추가
- OAuthException 커스텀예외 파일 추가
- ExternalJwtUtil 클래스 생성
  - 외부 서비스 전용 : RSA 공개 키 기반, 캐싱 필요
- AppleOAuthService 클래스 생성
  - 애플 공개 키 기반 토큰 검증
  - 서버요청 과다를 막기 위해 애플 공개 키는 redis로 관리 (12시간마다 재발급)
  - 토큰에서 유저 정보 추출
- 애플 소셜로그인 api 구현

---

## 🖼️ 기능 살펴 보기
> 애플 소셜로그인 api
<img width="1880" height="1280" alt="image" src="https://github.com/user-attachments/assets/c638e063-8e6c-478d-b745-2db32a54ae6c" />

> DB
<img width="2866" height="234" alt="image" src="https://github.com/user-attachments/assets/f97bc8a4-fad9-4c69-a522-e61cf5fe7cf9" />
- 연속된 로그인 테스트 시 시간만 업데이트, 새로운 유저로 잘못생기는 에러 등 없습니다

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] local - postman

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서
