### PR TITLE
Feat/term : 로그인 response 변경(회원가입인지 여부), 서비스약관 동의 전용 api 구현

### DIFF
--- a/src/main/java/_team/earnedit/controller/ProfileController.java
+++ b/src/main/java/_team/earnedit/controller/ProfileController.java
@@ -3,8 +3,10 @@ package _team.earnedit.controller;
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
 import _team.earnedit.dto.profile.SalaryRequestDto;
 import _team.earnedit.dto.profile.SalaryResponseDto;
+import _team.earnedit.dto.term.TermRequestDto;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.ProfileService;
+import _team.earnedit.service.TermService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +15,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/profile")
 public class ProfileController {
+
     private final ProfileService profileService;
+    private final TermService termService;
 
     @Operation(
             security = {@SecurityRequirement(name = "bearer-key")}
@@ -25,9 +31,24 @@ public class ProfileController {
     @PostMapping("/salary")
     public ResponseEntity<ApiResponse<SalaryResponseDto>> saveSalary(
             @AuthenticationPrincipal JwtUserInfoDto userInfo,
-            @RequestBody SalaryRequestDto requestDto) {
+            @RequestBody SalaryRequestDto requestDto)
+    {
         SalaryResponseDto responseDto = profileService.updateSalary(userInfo.getUserId(), requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("수익 정보를 업데이트했습니다",responseDto));
     }
+
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @PostMapping("/terms")
+    public ResponseEntity<ApiResponse<Void>> agreeToTerms(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @RequestBody List<TermRequestDto> requestDtos)
+    {
+        termService.agreeToTerms(userInfo.getUserId(), requestDtos);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("약관 동의 여부를 업데이트했습니다"));
+    }
+
 }

--- a/src/main/java/_team/earnedit/dto/auth/SignInResponseDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/SignInResponseDto.java
@@ -13,6 +13,6 @@ public class SignInResponseDto {
 
     private Long userId;
 
-    private boolean hasSalary;
+    private boolean isSignUp = false;
 
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -38,6 +38,9 @@ public enum ErrorCode {
     SALARY_NOT_FOUND(HttpStatus.NOT_FOUND, "조회된 급여 정보가 없습니다."),
 
 
+    // 약관 Term
+    TERM_MUST_BE_CHECKED(HttpStatus.BAD_REQUEST, "필수 약관 동의 여부는 true여야 합니다."),
+
     // 인증 Authentication
     AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),

--- a/src/main/java/_team/earnedit/global/exception/term/TermException.java
+++ b/src/main/java/_team/earnedit/global/exception/term/TermException.java
@@ -1,0 +1,18 @@
+package _team.earnedit.global.exception.term;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+
+public class TermException extends CustomException {
+  private final ErrorCode errorCode;
+
+  public TermException(ErrorCode errorCode) {
+    super(errorCode);
+    this.errorCode = errorCode;
+  }
+
+  public TermException(ErrorCode errorCode, String customMessage) {
+    super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/_team/earnedit/repository/TermRepository.java
+++ b/src/main/java/_team/earnedit/repository/TermRepository.java
@@ -1,7 +1,11 @@
 package _team.earnedit.repository;
 
 import _team.earnedit.entity.Term;
+import _team.earnedit.entity.Term.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
+
+    boolean existsByUserIdAndType(Long userId, Type type);
+
 }

--- a/src/main/java/_team/earnedit/repository/TermRepository.java
+++ b/src/main/java/_team/earnedit/repository/TermRepository.java
@@ -4,8 +4,10 @@ import _team.earnedit.entity.Term;
 import _team.earnedit.entity.Term.Type;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TermRepository extends JpaRepository<Term, Long> {
 
-    boolean existsByUserIdAndType(Long userId, Type type);
+    Optional<Term> findByUserIdAndType(Long userId, Type type);
 
 }

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -7,12 +7,12 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByEmail(String email);
-
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderAndProviderId(User.Provider provider, String providerId);
+
+    boolean existsByEmailAndProvider(String email, User.Provider provider);
 
 }

--- a/src/main/java/_team/earnedit/service/EmailVerificationService.java
+++ b/src/main/java/_team/earnedit/service/EmailVerificationService.java
@@ -1,6 +1,7 @@
 package _team.earnedit.service;
 
 import _team.earnedit.entity.EmailToken;
+import _team.earnedit.entity.User;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.repository.EmailTokenRepository;
@@ -27,7 +28,7 @@ public class EmailVerificationService {
 
         validateEmailFormat(email);
 
-        if (userRepository.existsByEmail(email)) {
+        if (userRepository.existsByEmailAndProvider(email, User.Provider.LOCAL)) {
             throw new UserException(ErrorCode.EMAIL_ALREADY_EXISTED);
         }
 

--- a/src/main/java/_team/earnedit/service/TermService.java
+++ b/src/main/java/_team/earnedit/service/TermService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/_team/earnedit/service/TermService.java
+++ b/src/main/java/_team/earnedit/service/TermService.java
@@ -1,0 +1,64 @@
+package _team.earnedit.service;
+
+import _team.earnedit.dto.term.TermRequestDto;
+import _team.earnedit.entity.Term;
+import _team.earnedit.entity.User;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.term.TermException;
+import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.repository.TermRepository;
+import _team.earnedit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TermService {
+
+    private final TermRepository termRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void agreeToTerms(Long userId, List<TermRequestDto> requestDtos) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        for (TermRequestDto dto : requestDtos) {
+            Term.Type type = dto.getType();
+            boolean isChecked = dto.isChecked();
+
+            // 필수 약관
+            if (isRequiredTerm(type) && !isChecked) {
+                throw new TermException(ErrorCode.TERM_MUST_BE_CHECKED);
+            }
+
+            Term existingTerm = termRepository.findByUserIdAndType(userId, type).orElse(null);
+
+            if (existingTerm != null) {
+                // 값이 다르면 업데이트
+                if (existingTerm.isChecked() != isChecked) {
+                    existingTerm.setChecked(isChecked);
+                    termRepository.save(existingTerm);
+                }
+            } else {
+                // 기존 데이터 없으면 새로 저장
+                Term term = Term.builder()
+                        .user(user)
+                        .type(type)
+                        .isChecked(isChecked)
+                        .build();
+                termRepository.save(term);
+            }
+        }
+    }
+
+    // 필수 약관 목록
+    private boolean isRequiredTerm(Term.Type type) {
+        return type == Term.Type.SERVICE_REQUIRED;
+    }
+
+}


### PR DESCRIPTION
## 📌 작업 개요
- 로그인 response 변경(회원가입인지 여부), 서비스약관 동의 전용 api 구현

---

## ✨ 주요 변경 사항

- 로그인 response 변경(회원가입인지 여부)
  - 소셜 로그인의 경우 회원가입과 동일 api를 사용하므로, 분기처리를 위해 데이터 수정

- 서비스약관 동의 전용 api 구현
  - 여러개의 서비스 약관을 한 번에 처리 가능
  - 필수약관 여부 검증 후 예외처리 있음
  - 기존 약관 데이터 없을 경우 추가, 있을 경우 update
  - 약관 추가 시 변경 용이하게 구현했습니다

---

## 🖼️ 기능 살펴 보기
> 기존에 있던 약관 동의여부 update
<img width="1788" height="1150" alt="image" src="https://github.com/user-attachments/assets/66c27f31-737f-4992-ab9c-d168c0f5ff74" />
<img width="1488" height="222" alt="image" src="https://github.com/user-attachments/assets/6f77dcfb-6b7a-4269-974d-6922d3ad440a" />

> 기존에 약관이 없을 땐 생성 (소셜로그인)
<img width="1466" height="280" alt="image" src="https://github.com/user-attachments/assets/d1c9da1f-5281-4f58-ba22-5e2e56bf0487" />


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman local

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

