### PR TITLE
Ref/response : 로그인 response dto 변경

### DIFF
--- a/src/main/java/_team/earnedit/controller/AuthController.java
+++ b/src/main/java/_team/earnedit/controller/AuthController.java
@@ -33,7 +33,7 @@ public class AuthController {
             @RequestBody SignInRequestDto requestDto
     ) {
         SignInResponseDto responseDto = authService.signIn(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success("로그인이 완료되었습니다.", responseDto));
     }
 

--- a/src/main/java/_team/earnedit/dto/auth/SignInResponseDto.java
+++ b/src/main/java/_team/earnedit/dto/auth/SignInResponseDto.java
@@ -13,6 +13,6 @@ public class SignInResponseDto {
 
     private Long userId;
 
-    private boolean isSignUp = false;
+    private boolean hasAgreedTerm;
 
 }

--- a/src/main/java/_team/earnedit/repository/TermRepository.java
+++ b/src/main/java/_team/earnedit/repository/TermRepository.java
@@ -10,4 +10,5 @@ public interface TermRepository extends JpaRepository<Term, Long> {
 
     Optional<Term> findByUserIdAndType(Long userId, Type type);
 
+    boolean existsByUserId(Long id);
 }

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -88,7 +88,7 @@ public class AuthService {
             throw new UserException(ErrorCode.INCORRECT_PASSWORD);
         }
 
-        return generateLoginResponse(user, false);
+        return generateLoginResponse(user);
     }
 
     // 소셜 로그인 : KAKAO
@@ -125,7 +125,7 @@ public class AuthService {
                 .status(User.Status.ACTIVE)
                 .build()));
 
-        return generateLoginResponse(user, isSignUp);
+        return generateLoginResponse(user);
     }
 
 
@@ -160,7 +160,7 @@ public class AuthService {
             throw new UserException(ErrorCode.USER_ALREADY_DELETED);
         }
 
-        return generateLoginResponse(user, isSignUp);
+        return generateLoginResponse(user);
     }
 
 
@@ -198,7 +198,7 @@ public class AuthService {
     }
 
     // JWT 발급 및 로그인 응답 생성
-    private SignInResponseDto generateLoginResponse(User user, boolean isSignUp) {
+    private SignInResponseDto generateLoginResponse(User user) {
         String[] tokens = jwtUtil.generateToken(new JwtUserInfoDto(user.getId()));
         String accessToken = tokens[0];
         String refreshToken = tokens[1];
@@ -209,7 +209,9 @@ public class AuthService {
         redisTemplate.opsForValue()
                 .set("refresh:" + user.getId(), refreshToken, Duration.ofMillis(jwtUtil.getRefreshTokenExpireTime()));
 
-        return new SignInResponseDto(accessToken, refreshToken, user.getId(), isSignUp);
+        boolean hasAgreedTerm = termRepository.existsByUserId(user.getId());
+
+        return new SignInResponseDto(accessToken, refreshToken, user.getId(), hasAgreedTerm);
     }
 
     private String generateUniqueNickname() {


### PR DESCRIPTION
## 📌 작업 개요
- 로그인 response dto 변경

---

## ✨ 주요 변경 사항
- 로그인 response dto 변경
  - 분기처리를 hasAgreedTerm로 하기로 

---

## 🖼️ 기능 살펴 보기
> 바뀐 response
<img width="1790" height="1232" alt="image" src="https://github.com/user-attachments/assets/aacbd6fa-b741-46bb-8cf1-7b71c6ad4b2d" />


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman
---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서
