### PR TITLE
fix : 자체로그인시 이메일 찾을 때 provider 같이 조회

### DIFF
--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmailAndProvider(String email, User.Provider provider);
 
+    Optional<User> findByEmailAndProvider(String email, User.Provider provider);
+
 }

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -77,7 +77,7 @@ public class AuthService {
     // 로그인
     @Transactional
     public SignInResponseDto signIn(SignInRequestDto requestDto) {
-        User user = userRepository.findByEmail(requestDto.getEmail())
+        User user = userRepository.findByEmailAndProvider(requestDto.getEmail(), User.Provider.LOCAL)
                 .orElseThrow(() -> new UserException(ErrorCode.EMAIL_NOT_FOUND));
 
         if (user.getStatus() == User.Status.DELETED) {


### PR DESCRIPTION
## 📌 작업 개요
- 자체로그인시 이메일 찾을 때 provider 같이 조회

---

## ✨ 주요 변경 사항
- 바뀐 이메일 unique 조건에 맞춰서 자체로그인 로직 변경

---

## 🖼️ 기능 살펴 보기
> 포스트맨 요청 응답 스크린샷
<img width="1804" height="1282" alt="image" src="https://github.com/user-attachments/assets/64ca04bb-e594-4e03-8ab5-5728c3797ed6" />

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

