### PR TITLE
Feat/user delete : 유저 탈퇴api, 탈퇴한 유저 복구로직, 탈퇴정책 로직 스케줄러 구현

### DIFF
--- a/src/main/java/_team/earnedit/controller/UserController.java
+++ b/src/main/java/_team/earnedit/controller/UserController.java
@@ -1,4 +1,32 @@
 package _team.earnedit.controller;
 
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.global.ApiResponse;
+import _team.earnedit.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> softDeleteUser(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        userService.softDeleteUser(userInfoDto.getUserId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("계정이 삭제되었습니다."));
+    }
 }

--- a/src/main/java/_team/earnedit/controller/UserController.java
+++ b/src/main/java/_team/earnedit/controller/UserController.java
@@ -1,0 +1,4 @@
+package _team.earnedit.controller;
+
+public class UserController {
+}

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -73,4 +73,10 @@ public class User {
     @Builder.Default
     @Column(nullable = false)
     private Boolean isPublic = false;
+
+    public void softDeleted() {
+        this.status = Status.DELETED;
+        this.deletedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -53,7 +53,11 @@ public class User {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @Column
     private LocalDateTime lastLoginAt;
+
+    @Column
+    private LocalDateTime deletedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "탈퇴한 회원입니다."),
 
+    USER_DELETION_EXPIRED_RECOVERY(HttpStatus.FORBIDDEN, "탈퇴한 지 30일이 넘어 복구할 수 없습니다."),
+
     // Wish
     ALREADY_EXITS_WISH(HttpStatus.CONFLICT, "이미 추가된 위시입니다."),
     WISH_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "이름은 공백값이 불가능합니다."),

--- a/src/main/java/_team/earnedit/global/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/UserCleanupScheduler.java
@@ -1,4 +1,31 @@
 package _team.earnedit.global.scheduler;
 
+import _team.earnedit.entity.User;
+import _team.earnedit.entity.User.Status;
+import _team.earnedit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class UserCleanupScheduler {
+
+    private final UserRepository userRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteUsersAfter3Years() {
+        LocalDateTime threshold = LocalDateTime.now().minusYears(3);
+        List<User> usersToDelete = userRepository.findByStatusAndDeletedAtBefore(Status.DELETED, threshold);
+
+        if (!usersToDelete.isEmpty()) {
+            userRepository.deleteAll(usersToDelete);
+            log.info("[hard-delete] {}명의 탈퇴한 사용자를 영구 삭제했습니다.", usersToDelete.size());
+        }
+    }
 }

--- a/src/main/java/_team/earnedit/global/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,4 @@
+package _team.earnedit.global.scheduler;
+
+public class UserCleanupScheduler {
+}

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -3,6 +3,8 @@ package _team.earnedit.repository;
 import _team.earnedit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,5 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAndProvider(String email, User.Provider provider);
 
     Optional<User> findByEmailAndProvider(String email, User.Provider provider);
+
+    List<User> findByStatusAndDeletedAtBefore(User.Status status, LocalDateTime threshold);
 
 }

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -22,4 +22,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findByStatusAndDeletedAtBefore(User.Status status, LocalDateTime threshold);
 
     List<User> findByStatusAndDeletedAtBeforeAndEmailNotContaining(User.Status status, LocalDateTime threshold, String deleted);
+
+    Optional<User> findByProviderAndProviderIdAndStatus(User.Provider provider, String kakaoId, User.Status status);
 }

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -21,4 +21,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findByStatusAndDeletedAtBefore(User.Status status, LocalDateTime threshold);
 
+    List<User> findByStatusAndDeletedAtBeforeAndEmailNotContaining(User.Status status, LocalDateTime threshold, String deleted);
 }

--- a/src/main/java/_team/earnedit/service/UserService.java
+++ b/src/main/java/_team/earnedit/service/UserService.java
@@ -1,4 +1,33 @@
 package _team.earnedit.service;
 
+import _team.earnedit.entity.User;
+import _team.earnedit.entity.User.Status;
+import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Transactional
+    public void softDeleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() == Status.DELETED) {
+            throw new UserException(ErrorCode.USER_ALREADY_DELETED);
+        }
+
+        user.softDeleted();
+
+        redisTemplate.delete("refresh:" + userId);
+    }
 }

--- a/src/main/java/_team/earnedit/service/UserService.java
+++ b/src/main/java/_team/earnedit/service/UserService.java
@@ -1,0 +1,4 @@
+package _team.earnedit.service;
+
+public class UserService {
+}


### PR DESCRIPTION
## 📌 작업 개요
- 유저 탈퇴api, 탈퇴한 유저 복구로직, 탈퇴정책 로직 스케줄러 구현

---

## ✨ 주요 변경 사항

⇒ 탈퇴 직후 기준 30일 이전 : 탈퇴한 이메일로 로그인 시도 시 → 이전 데이터 그대로 백업 (deleted → active)  /  탈퇴한 이메일로 회원가입 시도 시 → 중복된 이메일 예외

⇒ 탈퇴 직후 기준 30일 이후 : 탈퇴한 이메일로 재가입 시도 시 → **유저 입장에서는** 완전히 새 시작 (기존 탈퇴 회원의 email을 xxx@example.com_deleted_20250711 등으로 변경)

⇒ 탈퇴 직후 재가입 없이 3년 이후 : Hard delete (개인정보 보호법에 의거)

- 소셜 또한 모두 적용되었음

---

## 🖼️ 기능 살펴 보기
> 계정 삭제 (soft delete)
<img width="1792" height="1184" alt="image" src="https://github.com/user-attachments/assets/7ead5f24-9ff3-4f2e-b941-172b2a97d865" />
<img width="2624" height="514" alt="image" src="https://github.com/user-attachments/assets/984c180a-8ef7-4e0d-80dd-0dccded4e236" />

> 삭제된 계정으로 재로그인
<img width="1184" height="1306" alt="image" src="https://github.com/user-attachments/assets/be20ff5d-36a0-475e-a28c-3f2f076ba85c" />
<img width="2618" height="414" alt="image" src="https://github.com/user-attachments/assets/41668df6-d1d7-4f59-ab7f-e2961c4d2040" />

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] local <-> postman

---

## 💬 기타 참고 사항
- 로그아웃 구현과 함께 redis refresh 토큰 제거 구현 예정

---

## 📎 관련 이슈 / 문서

