### PR TITLE
Feat/salary : 1유저당 1 salary data로 수정(덮어쓰기로직), 수익조회 api 구현

### DIFF
--- a/src/main/java/_team/earnedit/controller/ProfileController.java
+++ b/src/main/java/_team/earnedit/controller/ProfileController.java
@@ -41,6 +41,19 @@ public class ProfileController {
     @Operation(
             security = {@SecurityRequirement(name = "bearer-key")}
     )
+    @GetMapping("/salary")
+    public ResponseEntity<ApiResponse<SalaryResponseDto>> getSalary(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo)
+    {
+        SalaryResponseDto responseDto = profileService.getSalary(userInfo.getUserId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("수익 정보를 조회했습니다", responseDto));
+    }
+
+
+    @Operation(
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @PostMapping("/terms")
     public ResponseEntity<ApiResponse<Void>> agreeToTerms(
             @AuthenticationPrincipal JwtUserInfoDto userInfo,

--- a/src/main/java/_team/earnedit/entity/Salary.java
+++ b/src/main/java/_team/earnedit/entity/Salary.java
@@ -19,12 +19,14 @@ public class Salary {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SalaryType type;
 
     private Boolean severance;
 
+    @Setter
     @Column(nullable = false)
     private Long amount;
 
@@ -32,12 +34,14 @@ public class Salary {
 
     private Long taxExemptAmount;
 
+    @Setter
     @Column(nullable = false)
     private Boolean tax = false;
 
     @Column(nullable = false)
     private Double amountPerSec;
 
+    @Setter
     @Column(nullable = false)
     private Integer payday;
 

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -4,6 +4,8 @@ import _team.earnedit.dto.profile.SalaryRequestDto;
 import _team.earnedit.dto.profile.SalaryResponseDto;
 import _team.earnedit.entity.Salary;
 import _team.earnedit.entity.User;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.salary.SalaryException;
 import _team.earnedit.global.util.SalaryCalculator;
 import _team.earnedit.repository.SalaryRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ public class ProfileService {
     private final SalaryRepository salaryRepository;
     private final SalaryCalculator salaryCalculator;
 
+    // 수익 정보 입력 + 수정 (덮어쓰기)
     @Transactional
     public SalaryResponseDto updateSalary(long userId, SalaryRequestDto requestDto) {
         Long amount = requestDto.getAmount();
@@ -48,8 +51,13 @@ public class ProfileService {
         return SalaryResponseDto.from(saved);
     }
 
-    // 수익 조회용 (예정)
-//    public SalaryResponseDto getSalary() {
-//
-//    }
+    // 수익 조회
+    @Transactional(readOnly = true)
+    public SalaryResponseDto getSalary(Long userId) {
+        Salary salary = salaryRepository.findByUserId(userId)
+                .orElseThrow(() -> new SalaryException(ErrorCode.SALARY_NOT_FOUND));
+
+        return SalaryResponseDto.from(salary);
+    }
+
 }


### PR DESCRIPTION
## 📌 작업 개요
- 1유저당 1 salary data로 수정(덮어쓰기로직), 수익조회 api 구현

---

## ✨ 주요 변경 사항
- 1유저당 1 salary data로 수정
  - 동일 api로 수익생성 & 수정 가능
- 수익조회 api 구현

---

## 🖼️ 기능 살펴 보기
> 수익 등록
<img width="1278" height="1452" alt="image" src="https://github.com/user-attachments/assets/4a1d57a6-894a-4559-a52b-99428b55bb69" />
<img width="1872" height="356" alt="image" src="https://github.com/user-attachments/assets/8ea5596b-1df1-424f-9b81-2573c7c206b9" />

> 수익 수정
<img width="1224" height="1414" alt="image" src="https://github.com/user-attachments/assets/85f08dc6-0768-440b-996a-076aad1429a3" />
<img width="1816" height="316" alt="image" src="https://github.com/user-attachments/assets/20f4a3ff-1225-41a0-8284-d34a082e0f48" />

> 수익 조회
<img width="1176" height="1292" alt="image" src="https://github.com/user-attachments/assets/d0235cd0-17e4-4d15-887a-0f39a5d1baf2" />


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] local postman

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

