### PR TITLE
ref: SALARY_NOT_FOUND 예외처리 제거

### DIFF
--- a/src/main/java/_team/earnedit/service/MainService.java
+++ b/src/main/java/_team/earnedit/service/MainService.java
@@ -4,10 +4,8 @@ import _team.earnedit.dto.main.MainPageResponse;
 import _team.earnedit.dto.wish.WishListResponse;
 import _team.earnedit.entity.Salary;
 import _team.earnedit.entity.Star;
-import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
-import _team.earnedit.global.exception.salary.SalaryException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.repository.SalaryRepository;
 import _team.earnedit.repository.StarRepository;
@@ -17,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,18 +29,20 @@ public class MainService {
     public MainPageResponse getInfo(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+//
+//        Salary salary = salaryRepository.findByUserId(userId)
+//                .orElseThrow(() -> new SalaryException(ErrorCode.SALARY_NOT_FOUND));
 
-        Salary salary = salaryRepository.findByUserId(userId)
-                .orElseThrow(() -> new SalaryException(ErrorCode.SALARY_NOT_FOUND));
+        Optional<Salary> salary = salaryRepository.findByUserId(userId);
 
-        boolean hasSalary = salaryRepository.existsByUserId(userId);
+        boolean hasSalary = salary.isPresent();
 
         // 유저 정보 (초당 수익, 수익 유무)
         MainPageResponse.UserInfo userInfo = MainPageResponse.UserInfo.builder()
-                .amount(salary.getAmount())
+                .amount(salary.map(Salary::getAmount).orElse(0L))
+                .amountPerSec(salary.map(Salary::getAmountPerSec).orElse(0.0))
+                .payday(salary.map(Salary::getPayday).orElse(0))
                 .hasSalary(hasSalary)
-                .amountPerSec(salary.getAmountPerSec())
-                .payday(salary.getPayday())
                 .build();
 
         // Top5 정보 조회


### PR DESCRIPTION
## 📌 작업 개요
- 사용자의 급여 정보 없을 때 예외 응답 제거
---

## ✨ 주요 변경 사항
- SALARY_NOT_FOUND 예외 던지지 않도록 수정
- hasSalary 1 or 0 응답, 그 외의 데이터 (amount, payday 등) hasSalary 0 일때 0 값으로 응답하도록 수정
---

## 🖼️ 기능 살펴 보기
>  <img width="638" height="454" alt="image" src="https://github.com/user-attachments/assets/269dc87a-7a22-4f30-bf56-ce49bc7c468b" />
- 급여 정보 있을 때 응답 (hasSalary = true, 그 밖의 값 정상 출력)

> <img width="573" height="424" alt="image" src="https://github.com/user-attachments/assets/a94e9e1b-d9f1-4f0c-8647-c953b3c19482" />
- 급여 정보 없을 때 응답 (hasSalary = false, 그 밖의 값 0으로 처리)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항
- 준영님 요청으로 수정하였습니다.

---

## 📎 관련 이슈 / 문서

