### PR TITLE
Feat/puzzle 도감 정보 조회 API, 조각 정보 조회, 추가 API 등

### DIFF
--- a/src/main/java/_team/earnedit/controller/DailyCheckController.java
+++ b/src/main/java/_team/earnedit/controller/DailyCheckController.java
@@ -1,0 +1,32 @@
+package _team.earnedit.controller;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.dto.puzzle.PieceResponse;
+import _team.earnedit.global.ApiResponse;
+import _team.earnedit.service.DailyCheckService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/daily-check")
+public class DailyCheckController {
+
+    private final DailyCheckService dailyCheckService;
+
+    @Operation(summary = "퍼즐에 조각 추가", description = "퍼즐에 해당 아이템을 추가합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @PostMapping("/{itemId}")
+    public ResponseEntity<ApiResponse<PieceResponse>> addPieceToPuzzle(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable long itemId) {
+
+        PieceResponse response = dailyCheckService.addPieceToPuzzle(userInfo.getUserId(), itemId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("조각이 퍼즐에 성공적으로 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/_team/earnedit/controller/DailyCheckController.java
+++ b/src/main/java/_team/earnedit/controller/DailyCheckController.java
@@ -6,6 +6,7 @@ import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.DailyCheckService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/daily-check")
+@Tag(name = "출석체크", description = "출석체크 API")
 public class DailyCheckController {
 
     private final DailyCheckService dailyCheckService;

--- a/src/main/java/_team/earnedit/controller/PuzzleController.java
+++ b/src/main/java/_team/earnedit/controller/PuzzleController.java
@@ -1,7 +1,9 @@
 package _team.earnedit.controller;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.dto.puzzle.PieceResponse;
 import _team.earnedit.dto.puzzle.PuzzleResponse;
+import _team.earnedit.entity.Piece;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.PuzzleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,20 +12,33 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/puzzle")
+@RequestMapping("/api")
 public class PuzzleController {
     private final PuzzleService puzzleService;
 
     @Operation(summary = "", description = "", security = {@SecurityRequirement(name = "bearer-key")})
-    @GetMapping
+    @GetMapping("/puzzle")
     public ResponseEntity<ApiResponse<PuzzleResponse>> getPuzzleInfo(@AuthenticationPrincipal JwtUserInfoDto userInfo) {
         PuzzleResponse response = puzzleService.getPuzzle(userInfo.getUserId());
         return ResponseEntity.ok(ApiResponse.success("퍼즐 정보를 불러왔습니다.", response));
     }
+
+    @Operation(summary = "", description = "", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/piece/{pieceId}")
+    public ResponseEntity<ApiResponse<PieceResponse>> getPieceInfo(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PathVariable Long pieceId
+    ) {
+        PieceResponse pieceInfo = puzzleService.getPieceInfo(userInfo.getUserId(), pieceId);
+        return ResponseEntity.ok(ApiResponse.success("퍼즐 정보를 불러왔습니다.", pieceInfo));
+    }
+
+
 }
 

--- a/src/main/java/_team/earnedit/controller/PuzzleController.java
+++ b/src/main/java/_team/earnedit/controller/PuzzleController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class PuzzleController {
     private final PuzzleService puzzleService;
 
-    @Operation(summary = "", description = "", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "퍼즐 정보 조회", description = "사용자의 퍼즐 정보를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/puzzle")
     public ResponseEntity<ApiResponse<PuzzleResponse>> getPuzzleInfo(@AuthenticationPrincipal JwtUserInfoDto userInfo) {
         PuzzleResponse response = puzzleService.getPuzzle(userInfo.getUserId());
         return ResponseEntity.ok(ApiResponse.success("퍼즐 정보를 불러왔습니다.", response));
     }
 
-    @Operation(summary = "", description = "", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "조각 정보 조회", description = "조각의 상세 정보를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
     @GetMapping("/piece/{pieceId}")
     public ResponseEntity<ApiResponse<PieceResponse>> getPieceInfo(
             @AuthenticationPrincipal JwtUserInfoDto userInfo,

--- a/src/main/java/_team/earnedit/controller/PuzzleController.java
+++ b/src/main/java/_team/earnedit/controller/PuzzleController.java
@@ -1,0 +1,31 @@
+package _team.earnedit.controller;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.global.ApiResponse;
+import _team.earnedit.service.PuzzleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/puzzle")
+public class PuzzleController {
+    private final PuzzleService puzzleService;
+
+    @GetMapping
+    @Operation(summary = "", description = "", security = {@SecurityRequirement(name = "bearer-key")})
+    public ResponseEntity<ApiResponse<String>> getPuzzle(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+        puzzleService.getPuzzle(userInfoDto.getUserId());
+
+    }
+
+
+}
+

--- a/src/main/java/_team/earnedit/controller/PuzzleController.java
+++ b/src/main/java/_team/earnedit/controller/PuzzleController.java
@@ -1,6 +1,7 @@
 package _team.earnedit.controller;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.dto.puzzle.PuzzleResponse;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.PuzzleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,14 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class PuzzleController {
     private final PuzzleService puzzleService;
 
-    @GetMapping
     @Operation(summary = "", description = "", security = {@SecurityRequirement(name = "bearer-key")})
-    public ResponseEntity<ApiResponse<String>> getPuzzle(
-            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
-        puzzleService.getPuzzle(userInfoDto.getUserId());
-
+    @GetMapping
+    public ResponseEntity<ApiResponse<PuzzleResponse>> getPuzzleInfo(@AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        PuzzleResponse response = puzzleService.getPuzzle(userInfo.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("퍼즐 정보를 불러왔습니다.", response));
     }
-
-
 }
 

--- a/src/main/java/_team/earnedit/controller/PuzzleController.java
+++ b/src/main/java/_team/earnedit/controller/PuzzleController.java
@@ -8,6 +8,7 @@ import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.PuzzleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "Puzzle", description = "Puzzle API")
 public class PuzzleController {
     private final PuzzleService puzzleService;
 
@@ -38,6 +40,16 @@ public class PuzzleController {
         PieceResponse pieceInfo = puzzleService.getPieceInfo(userInfo.getUserId(), pieceId);
         return ResponseEntity.ok(ApiResponse.success("퍼즐 정보를 불러왔습니다.", pieceInfo));
     }
+
+    @Operation(summary = "가장 최근 조각 조회", description = "가장 최근 조각의 상세 정보를 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @GetMapping("/piece/recent")
+    public ResponseEntity<ApiResponse<PieceResponse>> getPieceRecent(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo
+    ) {
+        PieceResponse pieceInfo = puzzleService.getPieceRecent(userInfo.getUserId());
+        return ResponseEntity.ok(ApiResponse.success("가장 최근 조각의 상세 정보를 조회했습니다.", pieceInfo));
+    }
+
 
 
 }

--- a/src/main/java/_team/earnedit/dto/main/MainPageResponse.java
+++ b/src/main/java/_team/earnedit/dto/main/MainPageResponse.java
@@ -1,5 +1,6 @@
 package _team.earnedit.dto.main;
 
+import _team.earnedit.dto.puzzle.PieceResponse;
 import _team.earnedit.dto.wish.WishListResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -17,6 +18,9 @@ public class MainPageResponse {
 
     @Schema(description = "Top 5 위시 리스트")
     private List<WishListResponse> starWishes;
+
+    @Schema(description = "조각 정보")
+    private PieceResponse pieceInfo;
 
     @Getter
     @Builder

--- a/src/main/java/_team/earnedit/dto/puzzle/PieceResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PieceResponse.java
@@ -1,0 +1,19 @@
+package _team.earnedit.dto.puzzle;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PieceResponse {
+    private Long pieceId;
+    private String rarity;
+    private LocalDateTime collectedAt;
+    private String image;
+    private String vendor;
+    private String name;
+    private long price;
+    private String description;
+}

--- a/src/main/java/_team/earnedit/dto/puzzle/PieceResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PieceResponse.java
@@ -1,5 +1,6 @@
 package _team.earnedit.dto.puzzle;
 
+import _team.earnedit.entity.Rarity;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class PieceResponse {
     private Long pieceId;
-    private String rarity;
+    private Rarity rarity;
     private LocalDateTime collectedAt;
     private String image;
     private String vendor;

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -1,34 +1,36 @@
 package _team.earnedit.dto.puzzle;
 
-
-import _team.earnedit.entity.Item;
-import _team.earnedit.entity.Piece;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
-@Builder
 @Getter
-@Schema(description = "퍼즐 응답 DTO")
+@Builder
 public class PuzzleResponse {
-    private PuzzleInfo puzzleInfo;
-    private Themes themes;
+    private Map<String, PuzzleThemeData> data;
 
-    @Builder
     @Getter
-    @Schema(description = "퍼즐 통계")
-    public static class PuzzleInfo {
-        private
+    @Builder
+    public static class PuzzleThemeData {
+        private String themeName;
+        private int collectedCount;
+        private int totalCount;
+        private long totalValue;
+        private List<SlotInfo> slots;
     }
 
-    @Builder
     @Getter
-    @Schema(description = "테마의 아이템")
-    public static class Themes {
-        List<Piece> pieces;
-
+    @Builder
+    public static class SlotInfo {
+        private int slotIndex;
+        private boolean isCollected;
+        private Long itemId;
+        private String itemName;
+        private String image;
+        private Long value;
+        private String collectedAt;
     }
-
 }

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -1,0 +1,34 @@
+package _team.earnedit.dto.puzzle;
+
+
+import _team.earnedit.entity.Item;
+import _team.earnedit.entity.Piece;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Schema(description = "퍼즐 응답 DTO")
+public class PuzzleResponse {
+    private PuzzleInfo puzzleInfo;
+    private Themes themes;
+
+    @Builder
+    @Getter
+    @Schema(description = "퍼즐 통계")
+    public static class PuzzleInfo {
+        private
+    }
+
+    @Builder
+    @Getter
+    @Schema(description = "테마의 아이템")
+    public static class Themes {
+        List<Piece> pieces;
+
+    }
+
+}

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -60,6 +61,6 @@ public class PuzzleResponse {
         private Long value;
 
         @Schema(description = "수집한 시각", example = "2025-07-31T12:00:00")
-        private String collectedAt;
+        private LocalDateTime collectedAt;
     }
 }

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -9,28 +9,57 @@ import java.util.Map;
 
 @Getter
 @Builder
+@Schema(description = "퍼즐 도감 전체 응답")
 public class PuzzleResponse {
+
+    @Schema(description = "테마별 퍼즐 정보", example = "{\"SWEET_AND_SOUR\": {...}, \"CS_MUST_HAVE\": {...}}")
     private Map<String, PuzzleThemeData> themes;
 
     @Getter
     @Builder
+    @Schema(description = "특정 테마의 퍼즐 정보")
     public static class PuzzleThemeData {
+
+        @Schema(description = "테마 이름", example = "새콤? 달콤!")
         private String themeName;
+
+        @Schema(description = "수집한 조각 개수", example = "2")
         private int collectedCount;
+
+        @Schema(description = "전체 조각 개수", example = "6")
         private int totalCount;
+
+        @Schema(description = "수집한 조각의 총 금액", example = "458000")
         private long totalValue;
+
+        @Schema(description = "퍼즐 슬롯 리스트")
         private List<SlotInfo> slots;
     }
 
     @Getter
     @Builder
+    @Schema(description = "퍼즐 슬롯 단위 정보")
     public static class SlotInfo {
+
+        @Schema(description = "퍼즐 슬롯 인덱스", example = "0")
         private int slotIndex;
+
+        @Schema(description = "수집 여부", example = "true")
         private boolean isCollected;
+
+        @Schema(description = "아이템 ID (수집된 경우에만 존재)", example = "10")
         private Long itemId;
+
+        @Schema(description = "아이템 이름 (수집된 경우에만 존재)", example = "에어팟 프로 2세대")
         private String itemName;
+
+        @Schema(description = "아이템 이미지 URL", example = "https://cdn.example.com/images/item.jpg")
         private String image;
+
+        @Schema(description = "아이템 가격", example = "329000")
         private Long value;
+
+        @Schema(description = "수집한 시각", example = "2025-07-31T12:00:00")
         private String collectedAt;
     }
 }

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -10,7 +10,7 @@ import java.util.Map;
 @Getter
 @Builder
 public class PuzzleResponse {
-    private Map<String, PuzzleThemeData> data;
+    private Map<String, PuzzleThemeData> themes;
 
     @Getter
     @Builder

--- a/src/main/java/_team/earnedit/entity/Item.java
+++ b/src/main/java/_team/earnedit/entity/Item.java
@@ -1,0 +1,41 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Item {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String vendor;
+
+    @Column(nullable = false)
+    private long price;
+
+    @Column(nullable = false)
+    private String image;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Rarity rarity;
+
+    @Enumerated(EnumType.STRING)
+    private Theme theme;
+
+    @Column(nullable = false)
+    private String description;
+}

--- a/src/main/java/_team/earnedit/entity/Piece.java
+++ b/src/main/java/_team/earnedit/entity/Piece.java
@@ -1,0 +1,37 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Piece {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(nullable = false)
+    private boolean isCollected;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime collectedAt;
+}

--- a/src/main/java/_team/earnedit/entity/PuzzleSlot.java
+++ b/src/main/java/_team/earnedit/entity/PuzzleSlot.java
@@ -1,0 +1,28 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PuzzleSlot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Theme theme;
+
+    @Column(nullable = false)
+    private int slotIndex;
+}

--- a/src/main/java/_team/earnedit/entity/Rarity.java
+++ b/src/main/java/_team/earnedit/entity/Rarity.java
@@ -1,0 +1,5 @@
+package _team.earnedit.entity;
+
+public enum Rarity {
+    S, A, B
+}

--- a/src/main/java/_team/earnedit/entity/Theme.java
+++ b/src/main/java/_team/earnedit/entity/Theme.java
@@ -1,0 +1,19 @@
+package _team.earnedit.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Theme {
+    SWEET_AND_SOUR("새콤? 달콤!"),
+    CS_MUST_HAVE("컴공과 필수템");
+
+    private final String displayName;
+
+    Theme(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @JsonValue
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -38,6 +38,12 @@ public enum ErrorCode {
 
     // Piece
     PIECE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 조각은 존재하지 않습니다."),
+    PIECE_ALREADY_ADD(HttpStatus.NOT_FOUND, "이미 퍼즐에 추가된 조각입니다."),
+
+
+    // Item
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 아이템은 존재하지 않습니다."),
+
 
 
     // Salary

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -36,6 +36,10 @@ public enum ErrorCode {
     TOP_WISH_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "Star는 5개를 초과할 수 없습니다."),
     TOP_WISH_EMPTY(HttpStatus.NOT_FOUND, "조회된 Star가 없습니다."),
 
+    // Piece
+    PIECE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 조각은 존재하지 않습니다."),
+
+
     // Salary
     SALARY_NOT_FOUND(HttpStatus.NOT_FOUND, "조회된 급여 정보가 없습니다."),
 

--- a/src/main/java/_team/earnedit/global/exception/item/ItemException.java
+++ b/src/main/java/_team/earnedit/global/exception/item/ItemException.java
@@ -1,0 +1,19 @@
+package _team.earnedit.global.exception.item;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+
+public class ItemException extends CustomException {
+    private final ErrorCode errorCode;
+
+    public ItemException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    public ItemException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+        this.errorCode = errorCode;
+    }
+}
+

--- a/src/main/java/_team/earnedit/global/exception/piece/PieceException.java
+++ b/src/main/java/_team/earnedit/global/exception/piece/PieceException.java
@@ -1,0 +1,18 @@
+package _team.earnedit.global.exception.piece;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+
+public class PieceException extends CustomException {
+    private final ErrorCode errorCode;
+
+    public PieceException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    public PieceException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/_team/earnedit/repository/ItemRepository.java
+++ b/src/main/java/_team/earnedit/repository/ItemRepository.java
@@ -1,0 +1,7 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/_team/earnedit/repository/PieceRepository.java
+++ b/src/main/java/_team/earnedit/repository/PieceRepository.java
@@ -1,0 +1,12 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.Piece;
+import _team.earnedit.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PieceRepository extends JpaRepository<Piece, Long> {
+    List<Piece> user(User user);
+    List<Piece> findByUserId(long userId);
+}

--- a/src/main/java/_team/earnedit/repository/PieceRepository.java
+++ b/src/main/java/_team/earnedit/repository/PieceRepository.java
@@ -1,5 +1,6 @@
 package _team.earnedit.repository;
 
+import _team.earnedit.entity.Item;
 import _team.earnedit.entity.Piece;
 import _team.earnedit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,5 @@ import java.util.List;
 public interface PieceRepository extends JpaRepository<Piece, Long> {
     List<Piece> user(User user);
     List<Piece> findByUserId(long userId);
+    List<Piece> findByItemAndUser(Item item, User user);
 }

--- a/src/main/java/_team/earnedit/repository/PieceRepository.java
+++ b/src/main/java/_team/earnedit/repository/PieceRepository.java
@@ -6,9 +6,11 @@ import _team.earnedit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PieceRepository extends JpaRepository<Piece, Long> {
     List<Piece> user(User user);
     List<Piece> findByUserId(long userId);
     List<Piece> findByItemAndUser(Item item, User user);
+    Optional<Piece> findTopByUserIdOrderByCollectedAtDesc(Long userId);
 }

--- a/src/main/java/_team/earnedit/repository/PuzzleSlotRepository.java
+++ b/src/main/java/_team/earnedit/repository/PuzzleSlotRepository.java
@@ -1,0 +1,7 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.PuzzleSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PuzzleSlotRepository extends JpaRepository<PuzzleSlot, Long> {
+}

--- a/src/main/java/_team/earnedit/service/DailyCheckService.java
+++ b/src/main/java/_team/earnedit/service/DailyCheckService.java
@@ -1,0 +1,60 @@
+package _team.earnedit.service;
+
+import _team.earnedit.dto.puzzle.PieceResponse;
+import _team.earnedit.entity.Item;
+import _team.earnedit.entity.Piece;
+import _team.earnedit.entity.User;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.item.ItemException;
+import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.repository.ItemRepository;
+import _team.earnedit.repository.PieceRepository;
+import _team.earnedit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class DailyCheckService {
+
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final PieceRepository pieceRepository;
+
+    @Transactional
+    public PieceResponse addPieceToPuzzle(Long userId, long itemId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new ItemException(ErrorCode.ITEM_NOT_FOUND));
+
+        List<Piece> pieceList = pieceRepository.findByItemAndUser(item, user);
+
+        // 이미 해당 itemId가 퍼즐에 등록되어있을 때
+        if (!pieceList.isEmpty()) {
+            throw new ItemException(ErrorCode.PIECE_ALREADY_ADD);
+        }
+
+        Piece piece = Piece.builder()
+                .user(user)
+                .item(item)
+                .isCollected(true)
+                .build();
+        pieceRepository.save(piece);
+
+        return PieceResponse.builder()
+                .pieceId(piece.getId())
+                .name(piece.getItem().getName())
+                .vendor(piece.getItem().getVendor())
+                .image(piece.getItem().getImage())
+                .price(piece.getItem().getPrice())
+                .description(piece.getItem().getDescription())
+                .rarity(piece.getItem().getRarity())
+                .collectedAt(piece.getCollectedAt())
+                .build();
+    }
+}

--- a/src/main/java/_team/earnedit/service/MainService.java
+++ b/src/main/java/_team/earnedit/service/MainService.java
@@ -1,12 +1,17 @@
 package _team.earnedit.service;
 
 import _team.earnedit.dto.main.MainPageResponse;
+import _team.earnedit.dto.puzzle.PieceResponse;
 import _team.earnedit.dto.wish.WishListResponse;
+import _team.earnedit.entity.Piece;
 import _team.earnedit.entity.Salary;
 import _team.earnedit.entity.Star;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.piece.PieceException;
+import _team.earnedit.global.exception.salary.SalaryException;
 import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.SalaryRepository;
 import _team.earnedit.repository.StarRepository;
 import _team.earnedit.repository.UserRepository;
@@ -24,6 +29,7 @@ public class MainService {
     private final UserRepository userRepository;
     private final SalaryRepository salaryRepository;
     private final StarRepository starRepository;
+    private final PieceRepository pieceRepository;
 
     @Transactional(readOnly = true)
     public MainPageResponse getInfo(Long userId) {
@@ -55,10 +61,28 @@ public class MainService {
                 })
                 .toList();
 
+        // 가장 최근 조각 1개 조회하여 삽입
+        Piece recentPiece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId)
+                .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+
+        // PieceResponse 객체 생성
+        PieceResponse pieceResponse = PieceResponse.builder()
+                .pieceId(recentPiece.getId())
+                .collectedAt(recentPiece.getCollectedAt())
+                .price(recentPiece.getItem().getPrice())
+                .rarity(recentPiece.getItem().getRarity())
+                .name(recentPiece.getItem().getName())
+                .image(recentPiece.getItem().getImage())
+                .vendor(recentPiece.getItem().getVendor())
+                .description(recentPiece.getItem().getDescription())
+                .build();
+
+
         // 응답 객체 생성
         return MainPageResponse.builder()
                 .starWishes(starWishList)
                 .userInfo(userInfo)
+                .pieceInfo(pieceResponse)
                 .build();
     }
 }

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -1,5 +1,6 @@
 package _team.earnedit.service;
 
+import _team.earnedit.dto.puzzle.PieceResponse;
 import _team.earnedit.dto.puzzle.PuzzleResponse;
 import _team.earnedit.entity.Item;
 import _team.earnedit.entity.Piece;
@@ -79,5 +80,10 @@ public class PuzzleService {
         return PuzzleResponse.builder()
                 .themes(responseMap)
                 .build();
+    }
+
+    public PieceResponse getPieceInfo(Long userId, Long pieceId) {
+
+
     }
 }

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -77,7 +77,7 @@ public class PuzzleService {
         }
 
         return PuzzleResponse.builder()
-                .data(responseMap)
+                .themes(responseMap)
                 .build();
     }
 }

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -107,4 +107,24 @@ public class PuzzleService {
                 .build();
 
     }
+
+    @Transactional(readOnly = true)
+    public PieceResponse getPieceRecent(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        Piece piece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId)
+                .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+
+        return PieceResponse.builder()
+                .pieceId(piece.getId())
+                .collectedAt(piece.getCollectedAt())
+                .price(piece.getItem().getPrice())
+                .description(piece.getItem().getDescription())
+                .image(piece.getItem().getImage())
+                .vendor(piece.getItem().getVendor())
+                .rarity(piece.getItem().getRarity())
+                .name(piece.getItem().getName())
+                .build();
+    }
 }

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -1,0 +1,14 @@
+package _team.earnedit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PuzzleService {
+
+    public void getPuzzle(Long userId) {
+
+
+    }
+}

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -6,8 +6,12 @@ import _team.earnedit.entity.Item;
 import _team.earnedit.entity.Piece;
 import _team.earnedit.entity.PuzzleSlot;
 import _team.earnedit.entity.Theme;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.piece.PieceException;
+import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.PuzzleSlotRepository;
+import _team.earnedit.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,6 +31,7 @@ public class PuzzleService {
 
     private final PuzzleSlotRepository puzzleSlotRepository;
     private final PieceRepository pieceRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public PuzzleResponse getPuzzle(Long userId) {
@@ -52,7 +57,7 @@ public class PuzzleService {
                     .itemName(isCollected ? item.getName() : null)
                     .image(isCollected ? item.getImage() : null)
                     .value(isCollected ? item.getPrice() : null)
-                    .collectedAt(isCollected ? piece.getCollectedAt().toString() : null)
+                    .collectedAt(isCollected ? piece.getCollectedAt() : null)
                     .build();
 
             Theme theme = slot.getTheme();
@@ -82,8 +87,24 @@ public class PuzzleService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public PieceResponse getPieceInfo(Long userId, Long pieceId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
+        Piece piece = pieceRepository.findById(pieceId)
+                .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+
+        return PieceResponse.builder()
+                .pieceId(piece.getId())
+                .collectedAt(piece.getCollectedAt())
+                .price(piece.getItem().getPrice())
+                .description(piece.getItem().getDescription())
+                .image(piece.getItem().getImage())
+                .vendor(piece.getItem().getVendor())
+                .rarity(piece.getItem().getRarity())
+                .name(piece.getItem().getName())
+                .build();
 
     }
 }

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -1,14 +1,83 @@
 package _team.earnedit.service;
 
+import _team.earnedit.dto.puzzle.PuzzleResponse;
+import _team.earnedit.entity.Item;
+import _team.earnedit.entity.Piece;
+import _team.earnedit.entity.PuzzleSlot;
+import _team.earnedit.entity.Theme;
+import _team.earnedit.repository.PieceRepository;
+import _team.earnedit.repository.PuzzleSlotRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PuzzleService {
 
-    public void getPuzzle(Long userId) {
+    private final PuzzleSlotRepository puzzleSlotRepository;
+    private final PieceRepository pieceRepository;
 
+    @Transactional(readOnly = true)
+    public PuzzleResponse getPuzzle(Long userId) {
+        List<PuzzleSlot> slots = puzzleSlotRepository.findAll();
+        List<Piece> pieces = pieceRepository.findByUserId(userId);
 
+        Map<Long, Piece> pieceMap = pieces.stream()
+                .collect(Collectors.toMap(p -> p.getItem().getId(), Function.identity()));
+
+        Map<Theme, List<PuzzleResponse.SlotInfo>> themeSlotMap = new HashMap<>();
+        Map<Theme, Integer> collectedCountMap = new HashMap<>();
+        Map<Theme, Long> totalValueMap = new HashMap<>();
+
+        for (PuzzleSlot slot : slots) {
+            Item item = slot.getItem();
+            Piece piece = pieceMap.get(item.getId());
+            boolean isCollected = piece != null && piece.isCollected();
+
+            PuzzleResponse.SlotInfo slotInfo = PuzzleResponse.SlotInfo.builder()
+                    .slotIndex(slot.getSlotIndex())
+                    .isCollected(isCollected)
+                    .itemId(isCollected ? item.getId() : null)
+                    .itemName(isCollected ? item.getName() : null)
+                    .image(isCollected ? item.getImage() : null)
+                    .value(isCollected ? item.getPrice() : null)
+                    .collectedAt(isCollected ? piece.getCollectedAt().toString() : null)
+                    .build();
+
+            Theme theme = slot.getTheme();
+            themeSlotMap.computeIfAbsent(theme, t -> new ArrayList<>()).add(slotInfo);
+            collectedCountMap.merge(theme, isCollected ? 1 : 0, Integer::sum);
+            totalValueMap.merge(theme, isCollected ? item.getPrice() : 0, Long::sum);
+        }
+
+        Map<String, PuzzleResponse.PuzzleThemeData> responseMap = new HashMap<>();
+        for (Map.Entry<Theme, List<PuzzleResponse.SlotInfo>> entry : themeSlotMap.entrySet()) {
+            Theme theme = entry.getKey();
+            List<PuzzleResponse.SlotInfo> themeSlots = entry.getValue();
+
+            PuzzleResponse.PuzzleThemeData themeData = PuzzleResponse.PuzzleThemeData.builder()
+                    .themeName(theme.getDisplayName())
+                    .collectedCount(collectedCountMap.getOrDefault(theme, 0))
+                    .totalCount(themeSlots.size())
+                    .totalValue(totalValueMap.getOrDefault(theme, 0L))
+                    .slots(themeSlots)
+                    .build();
+
+            responseMap.put(theme.name(), themeData);
+        }
+
+        return PuzzleResponse.builder()
+                .data(responseMap)
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 도감 정보 조회 API, 조각 정보 조회, 추가 API 등

---

## ✨ 주요 변경 사항
- 스웨거 문서화 

Puzzle
- 도감 정보 조회 API 
- 조각 정보 조회 API 
- 가장 최근 조각 정보 조회 API 

DailyCheck
- 선택한 item을 퍼즐에 등록 API 

MainPage
- 응답객체에 pieceInfo 추가

---

## 🖼️ 기능 살펴 보기

## Puzzle
> <img width="1430" height="1134" alt="image" src="https://github.com/user-attachments/assets/5348bc49-1ff5-460a-bec3-52611b7f7180" />
- 사용자의 퍼즐 정보 조회

> <img width="1419" height="1014" alt="image" src="https://github.com/user-attachments/assets/6c2676a4-4c4f-4e1f-80f2-fd897fe93178" />
- 퍼즐의 조각 id로 조회

> <img width="1416" height="905" alt="image" src="https://github.com/user-attachments/assets/2d22bb2c-bf25-4cf6-90aa-286bb7d0c6d5" />
- 가장 최근 획득한 조각 조회 


## DailyCheck
> <img width="1414" height="1084" alt="image" src="https://github.com/user-attachments/assets/65bfe12f-df76-4704-a743-799ab7217bcf" />
- 출석 체크 시, 지정한 아이템 사용자 퍼즐에 추가 

## MainPage
> <img width="448" height="234" alt="image" src="https://github.com/user-attachments/assets/d8dec6d9-3ecd-41a4-8749-d8a4bd7ef2d2" />
- 기존의 응답에 pieceInfo 추가 
- (이유) : 메인페이지 최초 불러올 때, 위시와 토글되는 조각 정보 세팅 위해서
---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- SwaggerUI
- 로컬 DB 더미데이터 세팅하여 테스트

---

## 💬 기타 참고 사항
- RDS DB의 item을 불러와서 등록하는 것은 아직 테스트해보지 않아서, 
3개의 랜덤 아이템 불러오는 API가 추가되면 정확하게 테스트가 가능할 것 같습니다.
- 퍼즐 테마? 카테고리가 정해지지 않아 RDS DB에 puzzle_slot 정보가 아직 등록되지 않았습니다.
따라서, 확정되어야 원격에 적용할 수 있는 부분이 있습니다

---

## 📎 관련 이슈 / 문서
