### PR TITLE
Ref/mainpage (프론트 요청) mainPage, 위시 추가 수정

### DIFF
--- a/src/main/java/_team/earnedit/dto/wish/WishAddRequest.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishAddRequest.java
@@ -30,4 +30,7 @@ public class WishAddRequest {
 
     @Schema(description = "상품 구매 URL", example = "https://store.example.com/products/item123")
     private String url;
+
+    @Schema(description = "Top 5 등록 여부", example = "true")
+    private boolean starred;
 }

--- a/src/main/java/_team/earnedit/service/MainService.java
+++ b/src/main/java/_team/earnedit/service/MainService.java
@@ -8,8 +8,6 @@ import _team.earnedit.entity.Salary;
 import _team.earnedit.entity.Star;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
-import _team.earnedit.global.exception.piece.PieceException;
-import _team.earnedit.global.exception.salary.SalaryException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.SalaryRepository;
@@ -62,27 +60,37 @@ public class MainService {
                 .toList();
 
         // 가장 최근 조각 1개 조회하여 삽입
-        Piece recentPiece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId)
-                .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+        // Piece recentPiece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId)
+        //.orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
 
-        // PieceResponse 객체 생성
-        PieceResponse pieceResponse = PieceResponse.builder()
-                .pieceId(recentPiece.getId())
-                .collectedAt(recentPiece.getCollectedAt())
-                .price(recentPiece.getItem().getPrice())
-                .rarity(recentPiece.getItem().getRarity())
-                .name(recentPiece.getItem().getName())
-                .image(recentPiece.getItem().getImage())
-                .vendor(recentPiece.getItem().getVendor())
-                .description(recentPiece.getItem().getDescription())
-                .build();
+        // 프론트 측 요청으로 예외를 던지지 않고, null 또는 빈값으로 응답
+        Optional<Piece> recentPiece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId);
 
+        if (recentPiece.isPresent()) {
+            // PieceResponse 객체 생성
+            PieceResponse pieceResponse = PieceResponse.builder()
+                    .pieceId(recentPiece.get().getId())
+                    .collectedAt(recentPiece.get().getCollectedAt())
+                    .price(recentPiece.get().getItem().getPrice())
+                    .rarity(recentPiece.get().getItem().getRarity())
+                    .name(recentPiece.get().getItem().getName())
+                    .image(recentPiece.get().getItem().getImage())
+                    .vendor(recentPiece.get().getItem().getVendor())
+                    .description(recentPiece.get().getItem().getDescription())
+                    .build();
 
+            // 응답 객체 생성
+            return MainPageResponse.builder()
+                    .starWishes(starWishList)
+                    .userInfo(userInfo)
+                    .pieceInfo(pieceResponse)
+                    .build();
+        }
         // 응답 객체 생성
         return MainPageResponse.builder()
                 .starWishes(starWishList)
                 .userInfo(userInfo)
-                .pieceInfo(pieceResponse)
+                .pieceInfo(null)
                 .build();
     }
 }

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -1,11 +1,14 @@
 package _team.earnedit.service;
 
 import _team.earnedit.dto.wish.*;
+import _team.earnedit.entity.Star;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.star.StarException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.exception.wish.WishException;
+import _team.earnedit.repository.StarRepository;
 import _team.earnedit.repository.UserRepository;
 import _team.earnedit.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +24,23 @@ import java.util.List;
 public class WishService {
     private final WishRepository wishRepository;
     private final UserRepository userRepository;
+    private final StarRepository starRepository;
 
     @Transactional
     public WishAddResponse addWish(WishAddRequest wishAddRequest, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        boolean isStarred = wishAddRequest.isStarred();
+        log.info("isStarred {}", isStarred);
+
+        // Top 5 초과 예외 처리
+        if (isStarred) {
+            int currentStarCount = starRepository.countByUserId(userId);
+            if (currentStarCount >= 5) {
+                throw new StarException(ErrorCode.TOP_WISH_LIMIT_EXCEEDED);
+            }
+        }
 
         // wish 객체 생성
         Wish wish = Wish.builder()
@@ -35,8 +50,21 @@ public class WishService {
                 .itemImage(wishAddRequest.getItemImage())
                 .name(wishAddRequest.getName())
                 .vendor(wishAddRequest.getVendor())
+                .isStarred(isStarred)
                 .build();
+
         wishRepository.save(wish);
+
+        // 별표 로직 분기
+        if (isStarred) {
+            int currentStarCount = starRepository.countByUserId(userId);  // 다시 조회하거나 변수 재사용
+            Star star = Star.builder()
+                    .user(user)
+                    .wish(wish)
+                    .rank(currentStarCount + 1)
+                    .build();
+            starRepository.save(star);
+        }
 
         return WishAddResponse.builder()
                 .wishId(wish.getId())


### PR DESCRIPTION
## 📌 작업 개요
- (프론트 요청) mainPage, 위시 추가 수정
---

## ✨ 주요 변경 사항
- mainPage 조회 시, piece 정보가 등록되어있지 않을 때 pieceInfo를 null로 응답하도록 수정
- 위시 추가 시, top5 등록 여부를 추가, 5개 초과 시 예외를 던지도록 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1391" height="232" alt="image" src="https://github.com/user-attachments/assets/69e6ad9a-8091-4781-9800-2feb8114e090" />
- 위시 추가 시, Star 5개 초과했을 때 예외 발생

> <img width="1387" height="515" alt="image" src="https://github.com/user-attachments/assets/43524818-25e2-45f1-a921-c33d0bb7f38f" />
- 메인페이지 정보 조회 시, 조각 정보 없으면 null로 응답


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항
- 프론트측 요청으로 수정
- 주말이므로 직접 Merge 진행

---

## 📎 관련 이슈 / 문서

