### PR TITLE
Feat/star-order-save Top5 순서 변경 API 

### DIFF
--- a/src/main/java/_team/earnedit/controller/StarController.java
+++ b/src/main/java/_team/earnedit/controller/StarController.java
@@ -2,6 +2,7 @@ package _team.earnedit.controller;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
 import _team.earnedit.dto.star.StarListResponse;
+import _team.earnedit.dto.star.StarOrderUpdateRequest;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.StarService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,15 +43,17 @@ public class StarController {
 
         return ResponseEntity.ok(ApiResponse.success("Star 목록을 조회했습니다.", starsWish));
     }
-//
-//    @PatchMapping("/order")
-//    @Operation(summary = "Star 순서 저장", description = "요청 받은 순서대로 서버에 Star 순서를 저장한다.", security = {@SecurityRequirement(name = "bearer-key")})
-//    public ResponseEntity<ApiResponse<Boolean>> updateStarOrder(
-//            @AuthenticationPrincipal JwtUserInfoDto userInfo,
-//
-//    ) {
-//        starService.updateStarOrder(userInfo.getUserId(), );
-//    }
+
+    @PatchMapping("/order")
+    @Operation(summary = "Star 순서 저장", description = "요청 받은 순서대로 서버에 Star 순서를 저장한다.", security = {@SecurityRequirement(name = "bearer-key")})
+    public ResponseEntity<ApiResponse<String>> updateStarOrder(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @RequestBody StarOrderUpdateRequest orderUpdateRequest
+            ) {
+        starService.updateStarOrder(userInfo.getUserId(), orderUpdateRequest.getOrderedWishIds());
+
+        return ResponseEntity.ok(ApiResponse.success("Star의 순서를 성공적으로 변경하였습니다."));
+    }
 
 
 

--- a/src/main/java/_team/earnedit/controller/StarController.java
+++ b/src/main/java/_team/earnedit/controller/StarController.java
@@ -1,7 +1,7 @@
 package _team.earnedit.controller;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
-import _team.earnedit.dto.wish.WishListResponse;
+import _team.earnedit.dto.star.StarListResponse;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.StarService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,12 +35,24 @@ public class StarController {
 
     @GetMapping
     @Operation(summary = "Star 목록 조회", description = "Star 목록을 조회합니다.", security = {@SecurityRequirement(name = "bearer-key")})
-    public ResponseEntity<ApiResponse<List<WishListResponse>>> getStarsWish(
+    public ResponseEntity<ApiResponse<List<StarListResponse>>> getStarsWish(
             @AuthenticationPrincipal JwtUserInfoDto userInfo
     ) {
-        List<WishListResponse> starsWish = starService.getStarsWish(userInfo.getUserId());
+        List<StarListResponse> starsWish = starService.getStarsWish(userInfo.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("Star 목록을 조회했습니다.", starsWish));
     }
+//
+//    @PatchMapping("/order")
+//    @Operation(summary = "Star 순서 저장", description = "요청 받은 순서대로 서버에 Star 순서를 저장한다.", security = {@SecurityRequirement(name = "bearer-key")})
+//    public ResponseEntity<ApiResponse<Boolean>> updateStarOrder(
+//            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+//
+//    ) {
+//        starService.updateStarOrder(userInfo.getUserId(), );
+//    }
+
+
+
 
 }

--- a/src/main/java/_team/earnedit/dto/star/StarListResponse.java
+++ b/src/main/java/_team/earnedit/dto/star/StarListResponse.java
@@ -1,0 +1,34 @@
+package _team.earnedit.dto.star;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@Schema(description = "Star 아이템 응답 DTO")
+public class StarListResponse {
+    @Schema(description = "Star ID", example = "1")
+    private Long id;
+
+    @Schema(description = "사용자 ID", example = "100")
+    private Long userId;
+
+    @Schema(description = "아이템 이름", example = "새콤달콤")
+    private String name;
+
+    @Schema(description = "가격", example = "85000")
+    private int price;
+
+    @Schema(description = "아이템 이미지 URL", example = "https://cdn.example.com/images/item123.png")
+    private String itemImage;
+
+    @Schema(description = "구매 여부", example = "false")
+    private boolean isBought;
+
+    @Schema(description = "판매자/브랜드명", example = "ABC")
+    private String vendor;
+
+    @Schema(description = "순서", example = "1~5")
+    private int rank;
+}

--- a/src/main/java/_team/earnedit/dto/star/StarListResponse.java
+++ b/src/main/java/_team/earnedit/dto/star/StarListResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Schema(description = "Star 아이템 응답 DTO")
 public class StarListResponse {
     @Schema(description = "Star ID", example = "1")
-    private Long id;
+    private Long starId;
 
     @Schema(description = "Wish ID", example = "1")
     private Long wishId;

--- a/src/main/java/_team/earnedit/dto/star/StarListResponse.java
+++ b/src/main/java/_team/earnedit/dto/star/StarListResponse.java
@@ -11,6 +11,9 @@ public class StarListResponse {
     @Schema(description = "Star ID", example = "1")
     private Long id;
 
+    @Schema(description = "Wish ID", example = "1")
+    private Long wishId;
+
     @Schema(description = "사용자 ID", example = "100")
     private Long userId;
 

--- a/src/main/java/_team/earnedit/dto/star/StarOrderUpdateRequest.java
+++ b/src/main/java/_team/earnedit/dto/star/StarOrderUpdateRequest.java
@@ -1,0 +1,13 @@
+package _team.earnedit.dto.star;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "Star 순서 변경 요청 DTO")
+public class StarOrderUpdateRequest {
+    @Schema(description = "위시 Id 리스트", example = "[34, 32, 31, 35, 30]")
+    private List<Long> orderedWishIds;
+}

--- a/src/main/java/_team/earnedit/entity/Star.java
+++ b/src/main/java/_team/earnedit/entity/Star.java
@@ -25,4 +25,8 @@ public class Star {
 
     @Setter
     private int rank;
+
+    public void updateRank(int rank) {
+        this.rank = rank;
+    }
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     // Star
     TOP_WISH_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "Star는 5개를 초과할 수 없습니다."),
     TOP_WISH_EMPTY(HttpStatus.NOT_FOUND, "조회된 Star가 없습니다."),
+    STAR_NOT_FOUND(HttpStatus.NOT_FOUND, "Star를 찾을 수 없습니다."),
 
     // Piece
     PIECE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 조각은 존재하지 않습니다."),

--- a/src/main/java/_team/earnedit/repository/StarRepository.java
+++ b/src/main/java/_team/earnedit/repository/StarRepository.java
@@ -12,4 +12,6 @@ public interface StarRepository extends JpaRepository<Star, Long> {
     void deleteByUserIdAndWishId(Long userId, Long wishId);
 
     List<Star> findByUserIdOrderByRankAsc(Long userId);
+
+    List<Star> findByUserId(Long userId);
 }

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -1,6 +1,6 @@
 package _team.earnedit.service;
 
-import _team.earnedit.dto.wish.WishListResponse;
+import _team.earnedit.dto.star.StarListResponse;
 import _team.earnedit.entity.Star;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
@@ -70,7 +70,7 @@ public class StarService {
     }
 
     @Transactional(readOnly = true)
-    public List<WishListResponse> getStarsWish(Long userId) {
+    public List<StarListResponse> getStarsWish(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
@@ -85,7 +85,17 @@ public class StarService {
         return stars.stream()
                 .map(star -> {
                     Wish wish = star.getWish();
-                    return WishListResponse.from(wish);  // 또는 WishListResponse 생성자 활용
+                    return StarListResponse.builder()
+                            .id(star.getId())
+                            .userId(star.getUser().getId())
+                            .name(wish.getName())
+                            .rank(star.getRank())
+                            .itemImage(wish.getItemImage())
+                            .vendor(wish.getVendor())
+                            .price(wish.getPrice())
+                            .rank(star.getRank())
+                            .isBought(wish.isBought())
+                            .build();
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -89,7 +89,7 @@ public class StarService {
                 .map(star -> {
                     Wish wish = star.getWish();
                     return StarListResponse.builder()
-                            .id(star.getId())
+                            .starId(star.getId())
                             .wishId(wish.getId())
                             .userId(star.getUser().getId())
                             .name(wish.getName())


### PR DESCRIPTION
## 📌 작업 개요
- Top5 순서 변경 API 추가

---

## ✨ 주요 변경 사항
- Top5 순서 변경 API 추가
- Star 목록 조회 응답 DTO 변경 (WishListResponse -> StarListResponse)
- 예외 추가 (Star Not Found)

---

## 🖼️ 기능 살펴 보기
> <img width="1466" height="1082" alt="image" src="https://github.com/user-attachments/assets/4838308b-469c-4f6c-8382-16e854bd904e" />
- 현재 wishId 저장된 순서는 41 ~ 45 순서

> <img width="1452" height="1252" alt="image" src="https://github.com/user-attachments/assets/845f5834-90fc-475c-8a14-7455adb86a5a" />
- 순서 변경 API 호출 (45,    44,    42,    41,    43)

> <img width="1304" height="429" alt="image" src="https://github.com/user-attachments/assets/cadf5c44-a55b-4319-84e0-7710afe9296b" />
- (45,    44,    42,    41,    43) 순서로 저장되어 정상적으로 호출 완료


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항
- 

---

## 📎 관련 이슈 / 문서

