### PR TITLE
Feat/search-wish 위시 검색 및 필터링 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,25 @@ dependencies {
 
 	// 유효성 검증
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// QueryDsl
+def querydslSrcDir = 'src/main/generated'
+
+clean {
+	delete file(querydslSrcDir)
+}
+
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/src/main/java/_team/earnedit/config/QueryDslConfig.java
+++ b/src/main/java/_team/earnedit/config/QueryDslConfig.java
@@ -1,0 +1,14 @@
+package _team.earnedit.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -1,5 +1,6 @@
 package _team.earnedit.controller;
 
+import _team.earnedit.dto.PagedResponse;
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
 import _team.earnedit.dto.wish.*;
 import _team.earnedit.global.ApiResponse;
@@ -13,6 +14,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -144,13 +148,18 @@ public class WishController {
             description = "검색어를 입력해 위시를 탐색합니다. ",
             security = {@SecurityRequirement(name = "bearer-key")}
     )
-    public ResponseEntity<ApiResponse<List<WishListResponse>>> searchWish(
+    public ResponseEntity<ApiResponse<PagedResponse<WishListResponse>>> searchWish(
             @AuthenticationPrincipal JwtUserInfoDto userInfo,
-            @ModelAttribute WishSearchCondition condition
+            @ModelAttribute WishSearchCondition condition,
+            @Parameter(
+                    name = "pageable",
+                    description = "페이징 정보 (예: page=0, size=10, sort=createdAt,desc)"
+            )
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<WishListResponse> wishListResponses = wishService.searchWish(userInfo.getUserId(), condition);
+        PagedResponse<WishListResponse> result = wishService.searchWish(userInfo.getUserId(), condition, pageable);
 
-        return ResponseEntity.ok(ApiResponse.success("검색 결과입니다.", wishListResponses));
+        return ResponseEntity.ok(ApiResponse.success("검색 결과입니다.", result));
     }
 
 }

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -146,11 +146,11 @@ public class WishController {
     )
     public ResponseEntity<ApiResponse<List<WishListResponse>>> searchWish(
             @AuthenticationPrincipal JwtUserInfoDto userInfo,
-            @RequestParam String keyword
+            @ModelAttribute WishSearchCondition condition
     ) {
-        List<WishListResponse> wishListResponses = wishService.searchWish(userInfo.getUserId(), keyword);
+        List<WishListResponse> wishListResponses = wishService.searchWish(userInfo.getUserId(), condition);
 
-        return ResponseEntity.ok(ApiResponse.success("검색어 결과입니다.", wishListResponses));
+        return ResponseEntity.ok(ApiResponse.success("검색 결과입니다.", wishListResponses));
     }
 
 }

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -138,4 +138,19 @@ public class WishController {
 
     }
 
+    @GetMapping("/search")
+    @Operation(
+            summary = "위시 검색",
+            description = "검색어를 입력해 위시를 탐색합니다. ",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<List<WishListResponse>>> searchWish(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @RequestParam String keyword
+    ) {
+        List<WishListResponse> wishListResponses = wishService.searchWish(userInfo.getUserId(), keyword);
+
+        return ResponseEntity.ok(ApiResponse.success("검색어 결과입니다.", wishListResponses));
+    }
+
 }

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -60,10 +60,12 @@ public class WishController {
             description = "사용자의 전체 위시 목록을 조회합니다.",
             security = {@SecurityRequirement(name = "bearer-key")}
     )
-    public ResponseEntity<ApiResponse<List<WishListResponse>>> getWishList(
-            @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+    public ResponseEntity<ApiResponse<PagedResponse<WishListResponse>>> getWishList(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @PageableDefault(size = 10, sort = "name", direction = Sort.Direction.DESC) Pageable pageable
+            ) {
 
-        List<WishListResponse> wishList = wishService.getWishList(userInfo.getUserId());
+        PagedResponse<WishListResponse> wishList = wishService.getWishList(userInfo.getUserId(), pageable);
 
         return ResponseEntity.ok(ApiResponse.success("위시 목록을 조회하였습니다.", wishList));
     }

--- a/src/main/java/_team/earnedit/dto/PagedResponse.java
+++ b/src/main/java/_team/earnedit/dto/PagedResponse.java
@@ -1,0 +1,19 @@
+package _team.earnedit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PagedResponse<T> {
+    private List<T> content;
+    private int page;         // 현재 페이지
+    private int size;         // 페이지 크기
+    private long totalElements; // 전체 데이터 수
+    private int totalPages;   // 전체 페이지 수
+    private boolean last;     // 마지막 페이지 여부
+}

--- a/src/main/java/_team/earnedit/dto/wish/WishSearchCondition.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishSearchCondition.java
@@ -19,10 +19,4 @@ public class WishSearchCondition {
 
     @Schema(description = "별표 여부", example = "false")
     private Boolean isStarred;
-
-    @Schema(description = "정렬 기준 필드", example = "price")
-    private String sort;
-
-    @Schema(description = "정렬 방향", example = "asc")
-    private String direction;
 }

--- a/src/main/java/_team/earnedit/dto/wish/WishSearchCondition.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishSearchCondition.java
@@ -1,0 +1,28 @@
+package _team.earnedit.dto.wish;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WishSearchCondition {
+    @Schema(description = "검색 키워드 (이름 또는 회사명)", example = "청바지")
+    private String keyword;
+
+    @Schema(description = "구매 완료 여부", example = "true")
+    private Boolean isBought;
+
+    @Schema(description = "별표 여부", example = "false")
+    private Boolean isStarred;
+
+    @Schema(description = "정렬 기준 필드", example = "price")
+    private String sort;
+
+    @Schema(description = "정렬 방향", example = "asc")
+    private String direction;
+}

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     WISH_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "상품 이미지는 반드시 있어야합니다."),
 
     WISHLIST_EMPTY(HttpStatus.NO_CONTENT, "등록된 위시가 없습니다."),
+    NOT_FOUND_SEARCH_RESULT(HttpStatus.NO_CONTENT, "검색 결과가 존재하지 않습니다."),
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 위시입니다."),
     WISH_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 수정 시도입니다."),
     WISH_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 삭제 시도입니다."),

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -27,8 +27,8 @@ public enum ErrorCode {
     WISH_PRICE_INVALID(HttpStatus.BAD_REQUEST, "상품의 가격은 0 이상이어야 합니다."),
     WISH_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "상품 이미지는 반드시 있어야합니다."),
 
-    WISHLIST_EMPTY(HttpStatus.NO_CONTENT, "등록된 위시가 없습니다."),
-    NOT_FOUND_SEARCH_RESULT(HttpStatus.NO_CONTENT, "검색 결과가 존재하지 않습니다."),
+    WISHLIST_EMPTY(HttpStatus.NOT_FOUND, "등록된 위시가 없습니다."),
+    NOT_FOUND_SEARCH_RESULT(HttpStatus.NOT_FOUND, "검색 결과가 존재하지 않습니다."),
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 위시입니다."),
     WISH_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 수정 시도입니다."),
     WISH_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 삭제 시도입니다."),

--- a/src/main/java/_team/earnedit/repository/WishRepository.java
+++ b/src/main/java/_team/earnedit/repository/WishRepository.java
@@ -1,5 +1,6 @@
 package _team.earnedit.repository;
 
+import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface WishRepository extends JpaRepository<Wish, Long> {
     List<Wish> findByUserId(Long userId);
     List<Wish> findByUserIdOrderByNameAsc(Long userId);
+    List<Wish> findByNameContainingIgnoreCaseAndUser(String name, User user);
 }

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -76,6 +76,8 @@ public class WishService {
                 .build();
     }
 
+
+    // Todo 페이지 네이션 작업해야함
     @Transactional(readOnly = true)
     public List<WishListResponse> getWishList(Long userId) {
         User user = userRepository.findById(userId)
@@ -215,5 +217,28 @@ public class WishService {
                         .build())
                 .toList();
 
+    }
+
+    @Transactional(readOnly = true)
+    public List<WishListResponse> searchWish(Long userId, String keyword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        // 해당 유저가 가진 위시 중에서 검색
+        List<Wish> result = wishRepository.findByNameContainingIgnoreCaseAndUser(keyword, user);
+
+        return result.stream()
+                .map(wish -> WishListResponse
+                        .builder()
+                        .name(wish.getName())
+                        .wishId(wish.getId())
+                        .price(wish.getPrice())
+                        .itemImage(wish.getItemImage())
+                        .isBought(wish.isBought())
+                        .vendor(wish.getVendor())
+                        .createdAt(wish.getCreatedAt())
+                        .isStarred(wish.isStarred())
+                        .build()
+                ).toList();
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 위시 검색 및 필터링 API 

---

## ✨ 주요 변경 사항
- 위시 검색 및 필터링 API
- QueryDsl 설정 및 의존성 추가

---

## 🖼️ 기능 살펴 보기
> <img width="839" height="418" alt="image" src="https://github.com/user-attachments/assets/64630cd9-1c4b-4120-85dd-56652ca848f3" />
- 위시 전체 조회 결과 (2개)

> <img width="1408" height="1106" alt="image" src="https://github.com/user-attachments/assets/25e06f34-8eff-4cfd-9224-c68820e08d5a" />
- 검색어 "청바지" 조회 결과 x 예외 처리

> <img width="1416" height="1317" alt="image" src="https://github.com/user-attachments/assets/c823b866-4db7-45f4-9570-0c84896ea510" />
- "아이폰" 검색, isBought = true 결과, 1개 조회

> <img width="1416" height="1317" alt="image" src="https://github.com/user-attachments/assets/7f6912c4-2b6a-4814-8d6a-bfd20f0e63d6" />
- "아이폰" 검색, isBought = false 결과, 예외 처리

> <img width="1413" height="1329" alt="image" src="https://github.com/user-attachments/assets/f6cf7de7-e8a6-482d-98ca-bbc2369a16a7" />
- isBought null, 검색어 빈값으로 세팅. 가격 기준 오름차순(asc) 정렬 (무선마우스 -> 아이폰 순서로 응답)

> <img width="1381" height="1409" alt="image" src="https://github.com/user-attachments/assets/4a39cb46-9329-4934-ba36-fde9588c13da" />
- isBought null, 검색어 빈값으로 세팅. 가격 기준 내림차순(desc) 정렬 (아이폰 -> 무선 마우스 순서로 응답)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서
