### PR TITLE
Ref/wish-highlight (프론트요청) 위시 하이라이트 API 응답 수정

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -149,10 +149,10 @@ public class WishController {
             description = "사용자의 하이라이트 위시(3개)를 조회합니다.",
             security = {@SecurityRequirement(name = "bearer-key")}
     )
-    public ResponseEntity<ApiResponse<List<WishDetailResponse>>> highlightWish(
+    public ResponseEntity<ApiResponse<WishHighlightResponse>> highlightWish(
             @AuthenticationPrincipal JwtUserInfoDto userInfo
     ) {
-        List<WishDetailResponse> response = wishService.highlightWish(userInfo.getUserId());
+        WishHighlightResponse response = wishService.highlightWish(userInfo.getUserId());
 
         return ResponseEntity.ok(ApiResponse.success("위시 하이라이트를 조회하였습니다.", response));
 

--- a/src/main/java/_team/earnedit/dto/wish/WishHighlightResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishHighlightResponse.java
@@ -1,0 +1,24 @@
+package _team.earnedit.dto.wish;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Schema(description = "위시 하이라이트 응답 DTO")
+public class WishHighlightResponse {
+
+    private WishInfo wishInfo;
+    private List<WishDetailResponse> wishDetailResponse;
+
+
+    @Builder
+    @Getter
+    @Schema(description = "위시 개수 응답 DTO")
+    public static class WishInfo {
+        private int currentWishCount;
+    }
+}

--- a/src/main/java/_team/earnedit/dto/wish/WishHighlightResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishHighlightResponse.java
@@ -11,14 +11,21 @@ import java.util.List;
 @Schema(description = "위시 하이라이트 응답 DTO")
 public class WishHighlightResponse {
 
+    @Schema(description = "위시 개수 정보")
     private WishInfo wishInfo;
-    private List<WishDetailResponse> wishDetailResponse;
 
+    @Schema(description = "최대 3개의 위시 목록")
+    private List<WishDetailResponse> wishHighlight;
 
     @Builder
     @Getter
     @Schema(description = "위시 개수 응답 DTO")
     public static class WishInfo {
+
+        @Schema(description = "현재 등록된 위시 개수", example = "23")
         private int currentWishCount;
+
+        @Schema(description = "등록 가능한 최대 위시 개수", example = "100")
+        private int limitWishCount;
     }
 }

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 위시입니다."),
     WISH_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 수정 시도입니다."),
     WISH_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "다른 사용자의 위시 삭제 시도입니다."),
+    WISH_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "위시는 100개까지만 추가할 수 있습니다."),
 
     // Star
     TOP_WISH_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "Star는 5개를 초과할 수 없습니다."),

--- a/src/main/java/_team/earnedit/repository/WishRepository.java
+++ b/src/main/java/_team/earnedit/repository/WishRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
-    List<Wish> findByUserId(Long userId);
     List<Wish> findByUserIdOrderByNameAsc(Long userId);
-    List<Wish> findByNameContainingIgnoreCaseAndUser(String name, User user);
+    int countByUser(User user);
 }


### PR DESCRIPTION
## 📌 작업 개요
- (프론트요청) 위시 하이라이트 API 응답 수정

---

## ✨ 주요 변경 사항
-  (프론트요청) 위시 하이라이트 API 응답 수정
- 위시 최대 추가 개수(100) 제한 로직 추가
---

## 🖼️ 기능 살펴 보기
> <img width="670" height="431" alt="image" src="https://github.com/user-attachments/assets/7ee28e4c-58cb-4bff-a39b-4442a084a091" />
- 위시 하이라이트 API 조회 시, 위시 제한 개수와 현재 갖고 있는 위시 개수 정보 함께 응답.

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- SwaggerUI

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

