### PR TITLE
Ref/star (프론트 요청) star 빈 배열로 응답 처리, 위시 업데이트 star여부 반영 안되는 문제 수정

### DIFF
--- a/src/main/java/_team/earnedit/dto/wish/WishUpdateRequest.java
+++ b/src/main/java/_team/earnedit/dto/wish/WishUpdateRequest.java
@@ -22,7 +22,7 @@ public class WishUpdateRequest {
 
     @NotNull(message = "가격은 필수입니다.")
     @Schema(description = "Star 여부", example = "true or false")
-    private boolean isStarred;
+    private boolean starred;
 
     @Schema(description = "상품 구매 URL", example = "https://smartstore.naver.com/item/123")
     private String url;

--- a/src/main/java/_team/earnedit/repository/StarRepository.java
+++ b/src/main/java/_team/earnedit/repository/StarRepository.java
@@ -1,6 +1,7 @@
 package _team.earnedit.repository;
 
 import _team.earnedit.entity.Star;
+import _team.earnedit.entity.Wish;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -16,4 +17,6 @@ public interface StarRepository extends JpaRepository<Star, Long> {
     List<Star> findByUserId(Long userId);
 
     void deleteByWishId(Long wishId);
+
+    boolean existsByUserIdAndWishId(Long userId, Long wishId);
 }

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -80,10 +80,11 @@ public class StarService {
         // 정렬된 순서로
         List<Star> stars = starRepository.findByUserIdOrderByRankAsc(userId);
 
-        // 조회된 Star가 없을 때
-        if (stars.isEmpty()) {
-            throw new StarException(ErrorCode.TOP_WISH_EMPTY);
-        }
+        // 프론트 요청으로 [] 로 응답
+//        // 조회된 Star가 없을 때
+//        if (stars.isEmpty()) {
+//            throw new StarException(ErrorCode.TOP_WISH_EMPTY);
+//        }
 
         return stars.stream()
                 .map(star -> {

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -159,6 +159,23 @@ public class WishService {
                 wishUpdateRequest.getUrl()
         );
 
+        if (!wishUpdateRequest.isStarred()) {
+            // star 제거
+            starRepository.deleteByWishId(wishId);
+        } else {
+            // 중복 방지: 이미 Star가 있는지 확인
+            boolean alreadyStarred = starRepository.existsByUserIdAndWishId(userId, wishId);
+            if (!alreadyStarred) {
+                int currentStarCount = starRepository.countByUserId(userId);
+                Star star = Star.builder()
+                        .user(user)
+                        .wish(wish)
+                        .rank(currentStarCount + 1)
+                        .build();
+                starRepository.save(star);
+            }
+        }
+
         return WishUpdateResponse.builder()
                 .wishId(wish.getId())
                 .name(wish.getName())


### PR DESCRIPTION
## 📌 작업 개요
- (프론트 요청) star 빈 배열로 응답 처리, 위시 업데이트 star여부 반영 안되는 문제 수정

---

## ✨ 주요 변경 사항
- star 조회 시, 데이터가 없을 때 예외를 던지던 것을 빈 배열로 응답 처리
- 위시 업데이트 API에서 star 반영 로직 수정, star 중복추가 방지 로직 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1432" height="811" alt="image" src="https://github.com/user-attachments/assets/d3444cd3-809a-498e-bc8f-6007bec0c38c" />
- star 비어있을 때,  [] 응답

> <img width="1460" height="1165" alt="image" src="https://github.com/user-attachments/assets/c5516716-eebd-4bd7-9f53-0a14e50653ea" />
- wishId 53 포함된 상태

> <img width="1430" height="655" alt="image" src="https://github.com/user-attachments/assets/9dacbe32-c748-4c6d-b5d7-c737db230164" />
- wishId 53 starred = false 로 지정 후 호출

> <img width="1447" height="1110" alt="image" src="https://github.com/user-attachments/assets/d029bd53-b0af-481d-9557-b75f5b09af1a" />
- starWish 목록이 비어있는걸 확인




---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

