### PR TITLE
Ref/domain-ex-separate 도메인 예외 메서드 분리 

### DIFF
--- a/src/main/java/_team/earnedit/global/util/EntityFinder.java
+++ b/src/main/java/_team/earnedit/global/util/EntityFinder.java
@@ -1,12 +1,15 @@
 package _team.earnedit.global.util;
 
+import _team.earnedit.entity.Item;
 import _team.earnedit.entity.Piece;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.item.ItemException;
 import _team.earnedit.global.exception.piece.PieceException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.exception.wish.WishException;
+import _team.earnedit.repository.ItemRepository;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.UserRepository;
 import _team.earnedit.repository.WishRepository;
@@ -20,6 +23,7 @@ public class EntityFinder {
     private final UserRepository userRepository;
     private final WishRepository wishRepository;
     private final PieceRepository pieceRepository;
+    private final ItemRepository itemRepository;
 
     public User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
@@ -34,5 +38,10 @@ public class EntityFinder {
     public Piece getPieceOrThrow(Long pieceId) {
         return  pieceRepository.findById(pieceId)
                 .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+    }
+
+    public Item getItemOrThrow(Long itemId) {
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new ItemException(ErrorCode.ITEM_NOT_FOUND));
     }
 }

--- a/src/main/java/_team/earnedit/global/util/EntityFinder.java
+++ b/src/main/java/_team/earnedit/global/util/EntityFinder.java
@@ -1,0 +1,20 @@
+package _team.earnedit.global.util;
+
+import _team.earnedit.entity.User;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EntityFinder {
+
+    private final UserRepository userRepository;
+
+    public User getUserOrThrow(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/_team/earnedit/global/util/EntityFinder.java
+++ b/src/main/java/_team/earnedit/global/util/EntityFinder.java
@@ -1,10 +1,13 @@
 package _team.earnedit.global.util;
 
+import _team.earnedit.entity.Piece;
 import _team.earnedit.entity.User;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.piece.PieceException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.exception.wish.WishException;
+import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.UserRepository;
 import _team.earnedit.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ public class EntityFinder {
 
     private final UserRepository userRepository;
     private final WishRepository wishRepository;
+    private final PieceRepository pieceRepository;
 
     public User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
@@ -27,4 +31,8 @@ public class EntityFinder {
                 .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
     }
 
+    public Piece getPieceOrThrow(Long pieceId) {
+        return  pieceRepository.findById(pieceId)
+                .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+    }
 }

--- a/src/main/java/_team/earnedit/global/util/EntityFinder.java
+++ b/src/main/java/_team/earnedit/global/util/EntityFinder.java
@@ -1,9 +1,12 @@
 package _team.earnedit.global.util;
 
 import _team.earnedit.entity.User;
+import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.exception.wish.WishException;
 import _team.earnedit.repository.UserRepository;
+import _team.earnedit.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,9 +15,16 @@ import org.springframework.stereotype.Component;
 public class EntityFinder {
 
     private final UserRepository userRepository;
+    private final WishRepository wishRepository;
 
-    public User getUserOrThrow(Long id) {
-        return userRepository.findById(id)
+    public User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
     }
+
+    public Wish getWishOrThrow(Long wishId) {
+        return wishRepository.findById(wishId)
+                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/_team/earnedit/service/DailyCheckService.java
+++ b/src/main/java/_team/earnedit/service/DailyCheckService.java
@@ -10,6 +10,7 @@ import _team.earnedit.entity.User;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.item.ItemException;
 import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.repository.ItemRepository;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.UserRepository;
@@ -35,16 +36,14 @@ public class DailyCheckService {
     private final ItemRepository itemRepository;
     private final PieceRepository pieceRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private final EntityFinder entityFinder;
 
     private static final Duration REWARD_TTL = Duration.ofMinutes(10); // 10분만 유효
 
     @Transactional
     public PieceResponse addPieceToPuzzle(Long userId, long itemId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new ItemException(ErrorCode.ITEM_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
+        Item item = entityFinder.getItemOrThrow(itemId);
 
         List<Piece> pieceList = pieceRepository.findByItemAndUser(item, user);
 
@@ -74,9 +73,7 @@ public class DailyCheckService {
 
     @Transactional
     public RewardCandidate generateRewardCandidates(Long userId) {
-
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
 
         List<Item> randomItems = itemRepository.findRandomItems(3);
         UUID rewardToken = UUID.randomUUID();

--- a/src/main/java/_team/earnedit/service/DailyCheckService.java
+++ b/src/main/java/_team/earnedit/service/DailyCheckService.java
@@ -32,7 +32,6 @@ public class DailyCheckService {
 
     private final ObjectMapper objectMapper;
 
-    private final UserRepository userRepository;
     private final ItemRepository itemRepository;
     private final PieceRepository pieceRepository;
     private final RedisTemplate<String, String> redisTemplate;
@@ -119,11 +118,8 @@ public class DailyCheckService {
             throw new IllegalArgumentException("유효하지 않은 보상 선택입니다.");
         }
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Item item = itemRepository.findById(request.getSelectedItemId())
-                .orElseThrow(() -> new ItemException(ErrorCode.ITEM_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
+        Item item = entityFinder.getItemOrThrow(request.getSelectedItemId());
 
         pieceRepository.save(Piece.builder()
                 .user(user)

--- a/src/main/java/_team/earnedit/service/MainService.java
+++ b/src/main/java/_team/earnedit/service/MainService.java
@@ -9,6 +9,7 @@ import _team.earnedit.entity.Star;
 import _team.earnedit.entity.Wish;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.SalaryRepository;
 import _team.earnedit.repository.StarRepository;
@@ -28,14 +29,11 @@ public class MainService {
     private final SalaryRepository salaryRepository;
     private final StarRepository starRepository;
     private final PieceRepository pieceRepository;
+    private final EntityFinder entityFinder;
 
     @Transactional(readOnly = true)
     public MainPageResponse getInfo(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-//
-//        Salary salary = salaryRepository.findByUserId(userId)
-//                .orElseThrow(() -> new SalaryException(ErrorCode.SALARY_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
 
         Optional<Salary> salary = salaryRepository.findByUserId(userId);
 

--- a/src/main/java/_team/earnedit/service/MainService.java
+++ b/src/main/java/_team/earnedit/service/MainService.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MainService {
 
-    private final UserRepository userRepository;
     private final SalaryRepository salaryRepository;
     private final StarRepository starRepository;
     private final PieceRepository pieceRepository;
@@ -56,10 +55,6 @@ public class MainService {
                     return WishListResponse.from(wish);  // 또는 WishListResponse 생성자 활용
                 })
                 .toList();
-
-        // 가장 최근 조각 1개 조회하여 삽입
-        // Piece recentPiece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId)
-        //.orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
 
         // 프론트 측 요청으로 예외를 던지지 않고, null 또는 빈값으로 응답
         Optional<Piece> recentPiece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId);

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -9,6 +9,7 @@ import _team.earnedit.entity.Theme;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.piece.PieceException;
 import _team.earnedit.global.exception.user.UserException;
+import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.PuzzleSlotRepository;
 import _team.earnedit.repository.UserRepository;
@@ -32,6 +33,7 @@ public class PuzzleService {
     private final PuzzleSlotRepository puzzleSlotRepository;
     private final PieceRepository pieceRepository;
     private final UserRepository userRepository;
+    private final EntityFinder entityFinder;
 
     @Transactional(readOnly = true)
     public PuzzleResponse getPuzzle(Long userId) {
@@ -89,11 +91,9 @@ public class PuzzleService {
 
     @Transactional(readOnly = true)
     public PieceResponse getPieceInfo(Long userId, Long pieceId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
 
-        Piece piece = pieceRepository.findById(pieceId)
-                .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));
+        Piece piece = entityFinder.getPieceOrThrow(pieceId);
 
         return PieceResponse.builder()
                 .pieceId(piece.getId())
@@ -110,8 +110,7 @@ public class PuzzleService {
 
     @Transactional(readOnly = true)
     public PieceResponse getPieceRecent(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
 
         Piece piece = pieceRepository.findTopByUserIdOrderByCollectedAtDesc(userId)
                 .orElseThrow(() -> new PieceException(ErrorCode.PIECE_NOT_FOUND));

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -32,7 +32,6 @@ public class PuzzleService {
 
     private final PuzzleSlotRepository puzzleSlotRepository;
     private final PieceRepository pieceRepository;
-    private final UserRepository userRepository;
     private final EntityFinder entityFinder;
 
     @Transactional(readOnly = true)

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -28,10 +28,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class StarService {
     private final StarRepository starRepository;
-    private final WishRepository wishRepository;
-    private final UserRepository userRepository;
     private final EntityFinder entityFinder;
-
 
     @Transactional
     public boolean updateStar(Long userId, long wishId) {

--- a/src/main/java/_team/earnedit/service/StarService.java
+++ b/src/main/java/_team/earnedit/service/StarService.java
@@ -9,6 +9,7 @@ import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.star.StarException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.exception.wish.WishException;
+import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.repository.StarRepository;
 import _team.earnedit.repository.UserRepository;
 import _team.earnedit.repository.WishRepository;
@@ -29,15 +30,14 @@ public class StarService {
     private final StarRepository starRepository;
     private final WishRepository wishRepository;
     private final UserRepository userRepository;
+    private final EntityFinder entityFinder;
 
 
     @Transactional
     public boolean updateStar(Long userId, long wishId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
 
-        Wish wish = wishRepository.findById(wishId)
-                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+        Wish wish = entityFinder.getWishOrThrow(wishId);
 
         boolean isStarred = wish.isStarred();
 
@@ -74,17 +74,10 @@ public class StarService {
 
     @Transactional(readOnly = true)
     public List<StarListResponse> getStarsWish(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
 
         // 정렬된 순서로
         List<Star> stars = starRepository.findByUserIdOrderByRankAsc(userId);
-
-        // 프론트 요청으로 [] 로 응답
-//        // 조회된 Star가 없을 때
-//        if (stars.isEmpty()) {
-//            throw new StarException(ErrorCode.TOP_WISH_EMPTY);
-//        }
 
         return stars.stream()
                 .map(star -> {
@@ -109,8 +102,8 @@ public class StarService {
 
     @Transactional
     public void updateStarOrder(Long userId, List<Long> orderedWishIds) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        entityFinder.getUserOrThrow(userId);
 
         List<Star> stars = starRepository.findByUserId(userId);
 

--- a/src/main/java/_team/earnedit/service/UserService.java
+++ b/src/main/java/_team/earnedit/service/UserService.java
@@ -4,7 +4,7 @@ import _team.earnedit.entity.User;
 import _team.earnedit.entity.User.Status;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.ErrorCode;
-import _team.earnedit.repository.UserRepository;
+import _team.earnedit.global.util.EntityFinder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -14,13 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private final EntityFinder entityFinder;
 
     @Transactional
     public void softDeleteUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
 
         if (user.getStatus() == Status.DELETED) {
             throw new UserException(ErrorCode.USER_ALREADY_DELETED);

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -37,7 +37,6 @@ public class WishService {
 
     public static final int MAX_WISH_COUNT = 100;
     private final WishRepository wishRepository;
-    private final UserRepository userRepository;
     private final StarRepository starRepository;
     private final FileUploadService fileUploadService;
     private final JPAQueryFactory queryFactory;

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -10,6 +10,7 @@ import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.star.StarException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.exception.wish.WishException;
+import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.repository.StarRepository;
 import _team.earnedit.repository.UserRepository;
 import _team.earnedit.repository.WishRepository;
@@ -40,11 +41,11 @@ public class WishService {
     private final StarRepository starRepository;
     private final FileUploadService fileUploadService;
     private final JPAQueryFactory queryFactory;
+    private final EntityFinder entityFinder;
 
     @Transactional
     public WishAddResponse addWish(WishAddRequest wishAddRequest, Long userId, MultipartFile itemImage) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
 
         // 위시 개수 제한 확인
         int currentWishCount = wishRepository.countByUser(user);
@@ -137,10 +138,8 @@ public class WishService {
 
     @Transactional
     public WishUpdateResponse updateWish(WishUpdateRequest wishUpdateRequest, Long userId, Long wishId, MultipartFile itemImage) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Wish wish = wishRepository.findById(wishId).orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
+        Wish wish = entityFinder.getWishOrThrow(wishId);
 
         // 이미지 업로드 처리
         String imageUrl = fileUploadService.uploadFile(itemImage);
@@ -189,11 +188,8 @@ public class WishService {
 
     @Transactional
     public void deleteWish(Long wishId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Wish wish = wishRepository.findById(wishId)
-                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
+        Wish wish = entityFinder.getWishOrThrow(wishId);
 
         // 다른 사용자의 삭제 시도에 대한 예외처리
         if (!wish.getUser().getId().equals(userId)) {
@@ -206,11 +202,8 @@ public class WishService {
 
     @Transactional(readOnly = true)
     public WishDetailResponse getWish(Long wishId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Wish wish = wishRepository.findById(wishId)
-                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
+        Wish wish = entityFinder.getWishOrThrow(wishId);
 
         return WishDetailResponse.builder()
                 .wishId(wish.getId())
@@ -229,11 +222,8 @@ public class WishService {
 
     @Transactional
     public boolean toggleBoughtStatus(Long wishId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
-
-        Wish wish = wishRepository.findById(wishId)
-                .orElseThrow(() -> new WishException(ErrorCode.WISH_NOT_FOUND));
+        entityFinder.getUserOrThrow(userId);
+        Wish wish = entityFinder.getWishOrThrow(wishId);
 
         wish.setBought(!wish.isBought());
 
@@ -242,8 +232,7 @@ public class WishService {
 
     @Transactional(readOnly = true)
     public WishHighlightResponse highlightWish(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+        User user = entityFinder.getUserOrThrow(userId);
 
         List<Wish> wishList = wishRepository.findByUserIdOrderByNameAsc(userId);
 


### PR DESCRIPTION
## 📌 작업 개요
- 도메인 예외 메서드 분리 

---

## ✨ 주요 변경 사항
- EntityFinder 클래스 분리하고, 각종 예외 메서드 정의
- 각 서비스단에서 호출하여 에외처리하도록 수정

---

## 🖼️ 기능 살펴 보기


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- 

---

## 💬 기타 참고 사항
- 이 부분은 한번 리뷰 부탁드립니다! @yoorym-kim 

---

## 📎 관련 이슈 / 문서
- 
