### PR TITLE
Ref/admin 테마별 필터링 기능 추가, Item.theme -> Item.category로 수정

### DIFF
--- a/src/main/java/_team/earnedit/controller/admin/ItemAdminController.java
+++ b/src/main/java/_team/earnedit/controller/admin/ItemAdminController.java
@@ -28,7 +28,6 @@ public class ItemAdminController {
     @GetMapping("/new")
     public String newForm(Model model) {
         model.addAttribute("item", new ItemRequest());
-        model.addAttribute("themes", Theme.values());
         model.addAttribute("rarities", Rarity.values());
         model.addAttribute("action", "/admin/items");
         return "admin/item-form";
@@ -39,7 +38,6 @@ public class ItemAdminController {
                        BindingResult bindingResult,
                        Model model) {
         if (bindingResult.hasErrors()) {
-            model.addAttribute("themes", Theme.values());
             model.addAttribute("rarities", Rarity.values());
             model.addAttribute("action", "/admin/items");
             return "admin/item-form";
@@ -53,7 +51,6 @@ public class ItemAdminController {
     public String editForm(@PathVariable Long id, Model model) {
         Item item = itemService.findById(id);
         model.addAttribute("item", ItemRequest.from(item));
-        model.addAttribute("themes", Theme.values());
         model.addAttribute("rarities", Rarity.values());
         model.addAttribute("action", "/admin/items/" + id + "/edit");
         return "admin/item-form";
@@ -65,7 +62,6 @@ public class ItemAdminController {
                          BindingResult bindingResult,
                          Model model) {
         if (bindingResult.hasErrors()) {
-            model.addAttribute("themes", Theme.values());
             model.addAttribute("rarities", Rarity.values());
             model.addAttribute("action", "/admin/items/" + id + "/edit");
             return "admin/item-form";

--- a/src/main/java/_team/earnedit/controller/admin/PuzzleSlotAdminController.java
+++ b/src/main/java/_team/earnedit/controller/admin/PuzzleSlotAdminController.java
@@ -26,11 +26,30 @@ public class PuzzleSlotAdminController {
     private final PuzzleSlotRepository puzzleSlotRepository;
 
     @GetMapping("/view")
-    public String list(Model model) {
-        model.addAttribute("slots", puzzleSlotService.findAll());
+    public String listPuzzleSlots(
+            @RequestParam(name = "theme", required = false) String themeParam,
+            Model model
+    ) {
+        Theme selectedTheme = null;
+        List<PuzzleSlot> slots;
+
+        if (themeParam != null && !themeParam.isBlank()) {
+            try {
+                selectedTheme = Theme.valueOf(themeParam);
+                slots = puzzleSlotRepository.findByTheme(selectedTheme);
+            } catch (IllegalArgumentException e) {
+                // 잘못된 theme 파라미터 처리
+                slots = puzzleSlotRepository.findAll();
+            }
+        } else {
+            slots = puzzleSlotRepository.findAll();
+        }
+
+        model.addAttribute("slots", slots);
+        model.addAttribute("themes", Theme.values());
+        model.addAttribute("selectedTheme", selectedTheme);
         return "admin/puzzle-slot-list";
     }
-
     @GetMapping("/new")
     public String newForm(Model model) {
         model.addAttribute("slot", new PuzzleSlotForm());

--- a/src/main/java/_team/earnedit/controller/admin/PuzzleSlotAdminController.java
+++ b/src/main/java/_team/earnedit/controller/admin/PuzzleSlotAdminController.java
@@ -59,9 +59,16 @@ public class PuzzleSlotAdminController {
     }
 
     @PostMapping
-    public String save(@ModelAttribute PuzzleSlotForm form) {
+    public String save(@ModelAttribute PuzzleSlotForm form, Model model) {
         puzzleSlotService.save(form);
-        return "redirect:/admin/puzzle-slots";
+
+        // form을 초기화하여 빈 상태로 다시 제공
+        model.addAttribute("slot", new PuzzleSlotForm());
+        model.addAttribute("themes", Theme.values());
+        model.addAttribute("items", itemService.findAll());
+        model.addAttribute("message", "슬롯이 성공적으로 저장되었습니다!");
+
+        return "admin/puzzle-slot-form"; // 📌 리다이렉트가 아닌 뷰 이름으로 반환
     }
 
     @GetMapping("/{id}/edit")

--- a/src/main/java/_team/earnedit/dto/item/ItemRequest.java
+++ b/src/main/java/_team/earnedit/dto/item/ItemRequest.java
@@ -31,8 +31,8 @@ public class ItemRequest {
     @NotNull(message = "희귀도를 선택해야 합니다.")
     private Rarity rarity;
 
-    @NotNull(message = "테마를 선택해야 합니다.")
-    private Theme theme;
+    @NotNull(message = "카테고리를 작성해야합니다.")
+    private String category;
 
     public Item toEntity(ItemRequest dto) {
         return Item.builder()
@@ -42,7 +42,7 @@ public class ItemRequest {
                 .image(dto.getImage())
                 .description(dto.getDescription())
                 .rarity(dto.getRarity())
-                .theme(dto.getTheme())
+                .category(dto.getCategory())
                 .build();
     }
 
@@ -54,7 +54,7 @@ public class ItemRequest {
         request.setImage(item.getImage());
         request.setDescription(item.getDescription());
         request.setRarity(item.getRarity());
-        request.setTheme(item.getTheme());
+        request.setCategory(item.getCategory());
         return request;
     }
 }

--- a/src/main/java/_team/earnedit/entity/Item.java
+++ b/src/main/java/_team/earnedit/entity/Item.java
@@ -31,20 +31,19 @@ public class Item {
     @Column(nullable = false)
     private Rarity rarity;
 
-    @Enumerated(EnumType.STRING)
-    private Theme theme;
+    private String category;
 
     @Column(nullable = false)
     private String description;
 
     public void update(String name, String vendor, long price, String image,
-                       String description, Rarity rarity, Theme theme) {
+                       String description, Rarity rarity, String category) {
         this.name = name;
         this.vendor = vendor;
         this.price = price;
         this.image = image;
         this.description = description;
         this.rarity = rarity;
-        this.theme = theme;
+        this.category = category;
     }
 }

--- a/src/main/java/_team/earnedit/repository/PuzzleSlotRepository.java
+++ b/src/main/java/_team/earnedit/repository/PuzzleSlotRepository.java
@@ -18,4 +18,6 @@ public interface PuzzleSlotRepository extends JpaRepository<PuzzleSlot, Long> {
     @Modifying
     @Query("DELETE FROM PuzzleSlot ps WHERE ps.item.id = :itemId")
     void deleteByItemId(@Param("itemId") Long itemId);
+
+    List<PuzzleSlot> findByTheme(Theme theme);
 }

--- a/src/main/java/_team/earnedit/service/admin/item/ItemServiceImpl.java
+++ b/src/main/java/_team/earnedit/service/admin/item/ItemServiceImpl.java
@@ -64,7 +64,7 @@ public class ItemServiceImpl implements ItemService {
                 request.getImage(),
                 request.getDescription(),
                 request.getRarity(),
-                request.getTheme()
+                request.getCategory()
         );
     }
 }

--- a/src/main/resources/templates/admin/item-form.html
+++ b/src/main/resources/templates/admin/item-form.html
@@ -106,12 +106,9 @@
         </select>
         <div th:if="${#fields.hasErrors('rarity')}" th:errors="*{rarity}" class="error"></div>
 
-        <label for="theme">테마</label>
-        <select th:field="*{theme}" id="theme" required>
-            <option value="">-- 선택하세요 --</option>
-            <option th:each="t : ${themes}" th:value="${t}" th:text="${t}"></option>
-        </select>
-        <div th:if="${#fields.hasErrors('theme')}" th:errors="*{theme}" class="error"></div>
+        <label for="category">카테고리</label>
+        <input type="text" th:field="*{category}" id="category" placeholder="예: CS_MUST_HAVE" required />
+        <div th:if="${#fields.hasErrors('category')}" th:errors="*{category}" class="error"></div>
 
         <button type="submit">저장</button>
     </form>

--- a/src/main/resources/templates/admin/item-list.html
+++ b/src/main/resources/templates/admin/item-list.html
@@ -99,7 +99,7 @@
             <th>ID</th>
             <th>이름</th>
             <th>가격</th>
-            <th>테마</th>
+            <th>카테고리</th>
             <th>수정</th>
             <th>삭제</th>
         </tr>
@@ -109,7 +109,7 @@
             <td th:text="${item.id}"></td>
             <td th:text="${item.name}"></td>
             <td th:text="${item.price} + '원'"></td>
-            <td th:text="${item.theme}"></td>
+            <td th:text="${item.category}"></td>
             <td>
                 <a th:href="@{/admin/items/{id}/edit(id=${item.id})}" class="action-button edit-btn">수정</a>
             </td>

--- a/src/main/resources/templates/admin/puzzle-slot-list.html
+++ b/src/main/resources/templates/admin/puzzle-slot-list.html
@@ -8,6 +8,18 @@
 <body class="container mt-5">
 <h2 class="mb-4">🧩 퍼즐 슬롯 목록</h2>
 
+<form method="get" action="/admin/puzzle-slots/view" class="mb-3 d-flex align-items-center">
+    <label for="theme" class="me-2">테마 필터:</label>
+    <select name="theme" id="theme" class="form-select w-auto me-2" onchange="this.form.submit()">
+        <option value="">전체</option>
+        <option th:each="t : ${themes}"
+                th:value="${t}"
+                th:text="${t}"
+                th:selected="${selectedTheme != null} ? ${selectedTheme} == ${t} : false">
+        </option>
+    </select>
+</form>
+
 <div class="mb-3">
     <a th:href="@{/admin/puzzle-slots/new}" class="btn btn-primary">➕ 새 슬롯 추가</a>
 </div>


### PR DESCRIPTION
## 📌 작업 개요
- 테마별 필터링 기능 추가, Item.theme -> Item.category로 수정

---

## ✨ 주요 변경 사항
- 테마별 필터링 기능 추가
- Item 도메인의 theme를 category 로 수정(아이템 도메인에 부적합하다는 생각이 듦)

---

## 🖼️ 기능 살펴 보기
> <img width="1277" height="614" alt="image" src="https://github.com/user-attachments/assets/47c060b9-7895-4b00-b2b2-acb7c9e94603" />
- 상단에 필터링 UI 추가

> <img width="1381" height="482" alt="image" src="https://github.com/user-attachments/assets/f21fe577-d789-4b58-87cd-786e8cc871f2" />
- 필터링 적용 시, 해당 테마 제품만 조회 가능

> <img width="679" height="774" alt="image" src="https://github.com/user-attachments/assets/2437c613-2ee4-4b80-8246-5f34c6a2a79d" />
- 물품 등록 시, 테마 선택 -> 카테고리 수기 입력으로 수정

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- 로컬 테스트
- Item DB를 밀고 데이터 재삽입

---

## 💬 기타 참고 사항
- Item 도메인에 엮여있을 필요가 없는 컬럼이라고 생각해서 Theme를 category로 수정하였습니다.
- 

---

## 📎 관련 이슈 / 문서

