### PR TITLE
Feat/colum : User 엔티티에 출석체크 컬럼추가, CheckInResetScheduler 구현

### DIFF
--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -95,4 +95,12 @@ public class User {
         this.profileImage = imageUrl;
     }
 
+    public void checkIn() { ////////////// 동훈님 코드에서 사용하십시오 ~
+        this.isCheckedIn = true;
+    }
+
+    public void resetCheckIn() {
+        this.isCheckedIn = false;
+    }
+
 }

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -74,6 +74,10 @@ public class User {
     @Column(nullable = false)
     private Boolean isPublic = false;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isCheckedIn = false;
+
     public void softDeleted() {
         this.status = Status.DELETED;
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
@@ -18,7 +18,7 @@ public class CheckInResetScheduler {
     private final UserRepository userRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void resetDailyCheckIn() {
         List<User> checkedInUsers = userRepository.findByIsCheckedInTrue();
         checkedInUsers.forEach(User::resetCheckIn);

--- a/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
@@ -1,14 +1,11 @@
 package _team.earnedit.global.scheduler;
 
-import _team.earnedit.entity.User;
 import _team.earnedit.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Component

--- a/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
@@ -1,0 +1,28 @@
+package _team.earnedit.global.scheduler;
+
+import _team.earnedit.entity.User;
+import _team.earnedit.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CheckInResetScheduler {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void resetDailyCheckIn() {
+        List<User> checkedInUsers = userRepository.findByIsCheckedInTrue();
+        checkedInUsers.forEach(User::resetCheckIn);
+
+        log.info("[CheckInResetScheduler] {}명의 출석체크 상태를 초기화했습니다.", checkedInUsers.size());
+    }
+}

--- a/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
+++ b/src/main/java/_team/earnedit/global/scheduler/CheckInResetScheduler.java
@@ -20,9 +20,8 @@ public class CheckInResetScheduler {
     @Transactional
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void resetDailyCheckIn() {
-        List<User> checkedInUsers = userRepository.findByIsCheckedInTrue();
-        checkedInUsers.forEach(User::resetCheckIn);
+        int updated = userRepository.resetAllCheckedIn();
 
-        log.info("[CheckInResetScheduler] {}명의 출석체크 상태를 초기화했습니다.", checkedInUsers.size());
+        log.info("[CheckInResetScheduler] {}명의 출석체크 상태를 초기화했습니다.", updated);
     }
 }

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -2,6 +2,9 @@ package _team.earnedit.repository;
 
 import _team.earnedit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,5 +28,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderIdAndStatus(User.Provider provider, String kakaoId, User.Status status);
 
-    List<User> findByIsCheckedInTrue();
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("update User u set u.isCheckedIn = false where u.isCheckedIn = true")
+    int resetAllCheckedIn();
 }

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -24,4 +24,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findByStatusAndDeletedAtBeforeAndEmailNotContaining(User.Status status, LocalDateTime threshold, String deleted);
 
     Optional<User> findByProviderAndProviderIdAndStatus(User.Provider provider, String kakaoId, User.Status status);
+
+    List<User> findByIsCheckedInTrue();
 }


### PR DESCRIPTION
## 📌 작업 개요
- User 엔티티에 출석체크 컬럼추가, CheckInResetScheduler 구현

---

## ✨ 주요 변경 사항
- User 엔티티에 출석체크 컬럼추가
- CheckInResetScheduler 구현
  - 쿼리메서드로 매일밤 자정에 전체유저 출석체크여부 false로 reset

---

## 🖼️ 기능 살펴 보기
> 

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 서버 db에 컬럼추가완료

---

## 📎 관련 이슈 / 문서

