### PR TITLE
fix : 비밀번호찾기 기능에서 local로 가입된 계정만 처리

### DIFF
--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -28,6 +28,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderIdAndStatus(User.Provider provider, String kakaoId, User.Status status);
 
+    boolean existsByEmail(String email);
+
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
     @Query("update User u set u.isCheckedIn = false where u.isCheckedIn = true")


### PR DESCRIPTION
## 📌 작업 개요
- 비밀번호찾기 기능에서 local로 가입된 계정만 처리

---

## ✨ 주요 변경 사항
`flutter: {"code":"DB_ACCESS_ERROR","message":"데이터베이스 오류 발생: Query did not return a unique result: 2 results were returned"}`

- 해당 오류 수정
---

## 🖼️ 기능 살펴 보기


---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

