### PR TITLE
Bug/puzzle 퍼즐 정보 조회 API 버그 수정, 조각 중복 추가 버그 수정

### DIFF
--- a/src/main/java/_team/earnedit/controller/PuzzleController.java
+++ b/src/main/java/_team/earnedit/controller/PuzzleController.java
@@ -3,7 +3,6 @@ package _team.earnedit.controller;
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
 import _team.earnedit.dto.puzzle.PieceResponse;
 import _team.earnedit.dto.puzzle.PuzzleResponse;
-import _team.earnedit.entity.Piece;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.PuzzleService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -73,19 +73,19 @@ public class PuzzleResponse {
     public static class PuzzleInfo {
 
         @Schema(description = "전체 테마 개수", example = "2")
-        private int themeCount;
+        private long themeCount;
 
         @Schema(description = "현재 완성한 테마 개수", example = "1")
-        private int completedThemeCount;
+        private long completedThemeCount;
 
         @Schema(description = "전체 조각 개수", example = "12")
-        private int totalPieceCount;
+        private long totalPieceCount;
 
         @Schema(description = "현재 완성한 조각 개수", example = "3")
-        private int completedPieceCount;
+        private long completedPieceCount;
 
         @Schema(description = "전체 누적 금액(원)", example = "33330")
-        private Long totalAccumulatedValue;
+        private long totalAccumulatedValue;
 
     }
 }

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -13,6 +13,9 @@ import java.util.Map;
 @Schema(description = "퍼즐 도감 전체 응답")
 public class PuzzleResponse {
 
+    @Schema(description = "퍼즐 정보 요약")
+    private PuzzleInfo puzzleInfo;
+
     @Schema(description = "테마별 퍼즐 정보", example = "{\"SWEET_AND_SOUR\": {...}, \"CS_MUST_HAVE\": {...}}")
     private Map<String, PuzzleThemeData> themes;
 
@@ -62,5 +65,27 @@ public class PuzzleResponse {
 
         @Schema(description = "수집한 시각", example = "2025-07-31T12:00:00")
         private LocalDateTime collectedAt;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "퍼즐 정보 요약")
+    public static class PuzzleInfo {
+
+        @Schema(description = "전체 테마 개수", example = "2")
+        private int themeCount;
+
+        @Schema(description = "현재 완성한 테마 개수", example = "1")
+        private int completedThemeCount;
+
+        @Schema(description = "전체 조각 개수", example = "12")
+        private int totalPieceCount;
+
+        @Schema(description = "현재 완성한 조각 개수", example = "3")
+        private int completedPieceCount;
+
+        @Schema(description = "전체 누적 금액(원)", example = "33330")
+        private Long totalAccumulatedValue;
+
     }
 }

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -51,6 +51,9 @@ public class PuzzleResponse {
         @Schema(description = "수집 여부", example = "true")
         private boolean isCollected;
 
+        @Schema(description = "조각 ID (수집된 경우에만 존재)", example = "101")
+        private Long pieceId;
+
         @Schema(description = "아이템 ID (수집된 경우에만 존재)", example = "10")
         private Long itemId;
 

--- a/src/main/java/_team/earnedit/dto/term/TermRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/term/TermRequestDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Schema(description = "약관 동의 요청 DTO")
 public class TermRequestDto {
 
-    @Schema(description = "약관 유형", example = "REQUIRED")
+    @Schema(description = "약관 유형", example = "SERVICE_REQUIRED")
     private Term.Type type;
 
     @Schema(description = "체크 여부", example = "true")

--- a/src/main/java/_team/earnedit/service/DailyCheckService.java
+++ b/src/main/java/_team/earnedit/service/DailyCheckService.java
@@ -9,6 +9,7 @@ import _team.earnedit.entity.Piece;
 import _team.earnedit.entity.User;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.item.ItemException;
+import _team.earnedit.global.exception.piece.PieceException;
 import _team.earnedit.global.exception.user.UserException;
 import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.repository.ItemRepository;
@@ -125,6 +126,12 @@ public class DailyCheckService {
 
         if (!candidateIds.contains(request.getSelectedItemId())) {
             throw new IllegalArgumentException("유효하지 않은 보상 선택입니다.");
+        }
+
+        List<Piece> pieceList = pieceRepository.findByItemAndUser(item, user);
+        // 이미 해당 아이템이 퍼즐에 추가되어있는지 검증
+        if (!pieceList.isEmpty()) {
+            throw new PieceException(ErrorCode.PIECE_ALREADY_ADD); // 이미 추가된 조각이라고 예외 던짐
         }
 
         pieceRepository.save(Piece.builder()

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -52,6 +52,7 @@ public class PuzzleService {
             PuzzleResponse.SlotInfo slotInfo = PuzzleResponse.SlotInfo.builder()
                     .slotIndex(slot.getSlotIndex())
                     .isCollected(isCollected)
+                    .pieceId(isCollected ? piece.getId() : null)
                     .itemId(isCollected ? item.getId() : null)
                     .itemName(isCollected ? item.getName() : null)
                     .image(isCollected ? item.getImage() : null)


### PR DESCRIPTION
## 📌 작업 개요
- 퍼즐 정보 조회 API 버그 수정, 조각 중복 추가 버그 수정

---

## ✨ 주요 변경 사항
- 퍼즐 정보 조회 API 버그 수정
- 조각 중복 추가 버그 수정
- puzzleInfo 데이터에 퍼즐 요약 정보 json 추가
- TermRequestDto에서 약관유형 example 값 수정 (스웨거 회원가입 테스트 시, 미작동 했음)
- PuzzleResponse에 pieceId 응답을 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1342" height="413" alt="image" src="https://github.com/user-attachments/assets/965a42ea-7d72-4015-ad61-cf31db1baa54" />
- /api/puzzle (GET) 요청 시, pieceId를 포함하여 응답

> <img width="1082" height="390" alt="image" src="https://github.com/user-attachments/assets/a595db0b-56bb-4806-a7db-1183ab0daadf" />
- 이미 추가한 조각 보상으로 선택하게 될 때, 중복 추가 방지 예외 던짐

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서

