### PR TITLE
Ref/security : JWT 인증/인가 구조 전면 정비 (+블랙리스트/헤더강화/엔드포인트 정리)

### DIFF
--- a/src/main/java/_team/earnedit/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/_team/earnedit/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package _team.earnedit.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       org.springframework.security.access.AccessDeniedException ex) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+        objectMapper.writeValue(response.getWriter(),
+                Map.of("code", "ACCESS_DENIED", "message", "권한이 없습니다."));
+    }
+}

--- a/src/main/java/_team/earnedit/config/security/JwtFilterConfig.java
+++ b/src/main/java/_team/earnedit/config/security/JwtFilterConfig.java
@@ -1,0 +1,21 @@
+package _team.earnedit.config.security;
+
+import _team.earnedit.global.jwt.JwtAuthFilter;
+import _team.earnedit.global.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtFilterConfig {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Bean
+    public JwtAuthFilter jwtAuthFilter() {
+        return new JwtAuthFilter(jwtUtil, redisTemplate);
+    }
+}

--- a/src/main/java/_team/earnedit/config/security/SecurityConfig.java
+++ b/src/main/java/_team/earnedit/config/security/SecurityConfig.java
@@ -59,11 +59,10 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**",
                                 "/images/**",
-                                "/api/auth/**"   // 로그인/회원가입 등 공개
+                                "/api/auth/**",// 로그인/회원가입 등 공개
+                                "/admin/**"// 관리자페이지 오픈
                         ).permitAll()
 
-                        ////////// 관리자페이지 막아놓기 (임시, 관리자페이지 보안설계 후 풀 것임)
-                        .requestMatchers("/admin/**").denyAll()
                         // 그 외 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/_team/earnedit/config/security/SecurityConfig.java
+++ b/src/main/java/_team/earnedit/config/security/SecurityConfig.java
@@ -2,12 +2,11 @@ package _team.earnedit.config.security;
 
 import _team.earnedit.global.jwt.JwtAuthFilter;
 import _team.earnedit.global.jwt.JwtAuthenticationEntryPoint;
-import _team.earnedit.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -18,21 +17,40 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@RequiredArgsConstructor
 @EnableWebSecurity
+@EnableMethodSecurity // @PreAuthorize 사용
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtUtil jwtUtil;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final JwtAuthFilter jwtAuthFilter; //Bean 주입
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .exceptionHandling(e -> e.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
+                .headers(h -> h
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .includeSubDomains(true).preload(true).maxAgeInSeconds(31536000))
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives("default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'"))
+                        .frameOptions(f -> f.sameOrigin())
+                        .referrerPolicy(r -> r.policy(org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER))
+                )
                 .authorizeHttpRequests(auth -> auth
+                        // 프리플라이트
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // 공개 리소스
                         .requestMatchers(
                                 "/health",
                                 "/swagger-ui/**",
@@ -40,12 +58,16 @@ public class SecurityConfig {
                                 "/api-docs/**",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/api/auth/**",
-                                "/admin/**",
-                                "/images/**").permitAll()
+                                "/images/**",
+                                "/api/auth/**"   // 로그인/회원가입 등 공개
+                        ).permitAll()
+
+                        ////////// 관리자페이지 막아놓기 (임시, 관리자페이지 보안설계 후 풀 것임)
+                        .requestMatchers("/admin/**").denyAll()
+                        // 그 외 인증 필요
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthFilter(jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/_team/earnedit/config/security/SecurityConfig.java
+++ b/src/main/java/_team/earnedit/config/security/SecurityConfig.java
@@ -59,8 +59,17 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**",
                                 "/images/**",
-                                "/api/auth/**",// 로그인/회원가입 등 공개
-                                "/admin/**"// 관리자페이지 오픈
+                                "/admin/**",// 관리자페이지 오픈
+
+                                "/api/auth/signup",
+                                "/api/auth/signin",
+                                "/api/auth/signin/kakao",
+                                "/api/auth/signin/apple",
+                                "/api/auth/refresh",
+                                "/api/auth/email/**",
+                                "/api/auth/password/**",
+
+                                "/api/upload"
                         ).permitAll()
 
                         // 그 외 인증 필요

--- a/src/main/java/_team/earnedit/controller/FileUploadController.java
+++ b/src/main/java/_team/earnedit/controller/FileUploadController.java
@@ -1,5 +1,6 @@
 package _team.earnedit.controller;
 
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.FileUploadService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,10 +28,12 @@ public class FileUploadController {
 
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "사진 업로드", description = "입력받은 사진 또는 파일을 S3에 업로드합니다.", security = {@SecurityRequirement(name = "bearer-key")})
+    @Operation(summary = "사진 업로드", description = "입력받은 사진 또는 파일을 S3에 업로드합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")})
     public ResponseEntity<ApiResponse<String>> uploadFile(
             @Parameter(description = "업로드할 이미지 파일", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
-            @RequestParam("file") MultipartFile file) {
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
         String url = fileUploadService.uploadFile(file);
 
         return ResponseEntity.ok(ApiResponse.success("file successfully uploaded", url));

--- a/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
@@ -1,6 +1,8 @@
 package _team.earnedit.global.jwt;
 
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.ErrorResponse;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.jsonwebtoken.Claims;
@@ -14,10 +16,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -27,49 +31,92 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
 
+    // 5분 중복로그 방지 캐시
     private final Cache<String, Boolean> expiredTokenLogCache = Caffeine.newBuilder()
-            .expireAfterWrite(5, TimeUnit.MINUTES) // 5분 후 삭제
-            .maximumSize(1000) // 최대 1000개
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .maximumSize(1000)
             .build();
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        // 헤더에서 토큰 추출
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
         String token = jwtUtil.resolveToken(request);
+        if (token == null) {
+            // Authorization이 없으면 쿠키 fallback
+            token = jwtUtil.extractTokenFromCookies(request);
+        }
 
         // 토큰 유효성 검사
         try {
-            if (token != null && jwtUtil.validateAccessToken(token)) {
-
-                // 로그아웃(블랙리스트) 체크
-                if (redisTemplate.hasKey("BL:" + token)) {
-                    log.warn("블랙리스트 토큰 접근 시도: {}", token);
-                    throw new AuthenticationException("BLACKLISTED") {
-                    };
+            if (token != null) {
+                // 1) 블랙리스트 즉시 차단
+                String blKey = "BL:" + token;
+                if (Boolean.TRUE.equals(redisTemplate.hasKey(blKey))) {
+                    // 토큰 원문 로그 금지 → 일부 해시만
+                    log.warn("블랙리스트 토큰 접근 시도: {}...", safeTokenSuffix(token));
+                    unauthorized(response, "TOKEN_BLACKLISTED", "로그아웃된 토큰입니다.");
+                    return;
                 }
 
+                // 2) 접근 토큰 유효성 검증
+                if (!jwtUtil.validateAccessToken(token)) {
+                    unauthorized(response, "INVALID_TOKEN", "유효하지 않은 토큰입니다.");
+                    return;
+                }
+
+                // 3) 클레임 파싱 & 인증 주입
                 Claims claims = jwtUtil.parseClaims(token);
                 Long userId = Long.valueOf(claims.getSubject());
 
-                // 인증 객체 생성
                 JwtUserInfoDto userInfo = new JwtUserInfoDto(userId);
-                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userInfo, null, null);
+                var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 
-                // 시큐리티 컨텍스트에 저장
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(userInfo, null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
+
+            filterChain.doFilter(request, response);
+
         } catch (ExpiredJwtException e) {
-            if (expiredTokenLogCache.getIfPresent(token) == null) {
-                log.warn("만료된 JWT: {}", e.getMessage());
+            if (token != null && expiredTokenLogCache.getIfPresent(token) == null) {
+                log.warn("만료된 JWT 접근 감지: {}", e.getMessage());
                 expiredTokenLogCache.put(token, true);
             }
+            unauthorized(response, "TOKEN_EXPIRED", "만료된 토큰입니다.");
+        } catch (Exception e) {
+            log.error("JWT 필터 처리 중 예외", e);
+            unauthorized(response, "AUTH_ERROR", "인증 처리 중 오류가 발생했습니다.");
         }
-        filterChain.doFilter(request,response);
     }
 
+    // 엔드포인트 예외 (필터 미적용)
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.equals("/api/auth/refresh") || path.startsWith("/swagger") || path.startsWith("/v3/api-docs");
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) return true;
+        return path.equals("/health")
+                || path.startsWith("/api/auth/")     // 로그인/회원가입/리프레시 등
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/swagger")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/api-docs")
+                || path.startsWith("/swagger-resources")
+                || path.startsWith("/webjars")
+                || path.startsWith("/images/");
+    }
+
+    private void unauthorized(HttpServletResponse response, String code, String message) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        var body = ErrorResponse.fail(ErrorCode.AUTH_REQUIRED, message);
+
+        new com.fasterxml.jackson.databind.ObjectMapper().writeValue(response.getWriter(), body);
+    }
+
+    private String safeTokenSuffix(String token) {
+        return token.length() > 10 ? token.substring(token.length() - 10) : token;
     }
 }

--- a/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/_team/earnedit/global/jwt/JwtAuthFilter.java
@@ -97,7 +97,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) return true;
         return path.equals("/health")
-                || path.startsWith("/api/auth/")     // 로그인/회원가입/리프레시 등
+                || path.equals("/api/auth/refresh")
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/swagger")
                 || path.startsWith("/v3/api-docs")

--- a/src/main/java/_team/earnedit/service/AuthService.java
+++ b/src/main/java/_team/earnedit/service/AuthService.java
@@ -206,8 +206,7 @@ public class AuthService {
 
         // access token 블랙리스트 등록
         Date expiration = jwtUtil.getAccessTokenExpiration(accessToken);
-        long now = System.currentTimeMillis();
-        long ttl = expiration.getTime() - now;
+        long ttl = Math.max(1000L, expiration.getTime() - System.currentTimeMillis());
 
         redisTemplate.opsForValue()
                 .set("BL:" + accessToken, "logout", ttl, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## 📌 작업 개요
- JWT 인증/인가 구조 전면 정비

---

## ✨ 주요 변경 사항
-JWT 기반 인증 필터를 전면 개선, 인가 규칙을 엔드포인트별로 명시
- 로그아웃 토큰 블랙리스트가 필터 레벨에서 선차단되며, 만료/무효 토큰은 일관된 JSON으로 즉시 401 응답
- /admin/**는 기존대로 임시 올 허용
  - 나중에 별도 관리자 보안을 설계 예정
- Flutter 앱 기준으로 CORS 의존 제거(기존 CorsConfig는 유지)
- 운영 안전성/가시성 향상을 위한 보안 헤더(HSTS/CSP 등) 적용

---

## 🖼️ 기능 살펴 보기
> 기존 로그인 -> 진입 good (인증필요 x)
<img width="2014" height="1422" alt="image" src="https://github.com/user-attachments/assets/08a68933-eca1-4f7d-a8c9-3fbc3b91fc3d" />

> 발급 토큰으로 인증필요 api 호출 -> 진입 good
<img width="1814" height="1472" alt="image" src="https://github.com/user-attachments/assets/e10082ae-8c09-462c-8fad-b48bb4218193" />

> 발급 토큰으로 로그아웃 처리 -> 진입 good
<img width="2022" height="1360" alt="image" src="https://github.com/user-attachments/assets/122dec0e-7b00-49fb-902d-724fc37d749e" />

> 로그아웃된 계정의 토큰으로 api 호출 -> 블랙리스트 처리된 토큰이므로 접근x
<img width="2032" height="1292" alt="image" src="https://github.com/user-attachments/assets/474524a0-4c86-442b-9346-36642d47a04d" />

> 로그아웃된 계정의 refresh 토큰으로 refresh api 호출 -> 마찬가지로 접근x, 발급 불가
<img width="2020" height="1308" alt="image" src="https://github.com/user-attachments/assets/287fe2be-a944-4a62-ab8f-27d746e4378c" />

> 같은 계정 재로그인 후, 새로운 토큰으로 refresh -> 잘 작동
<img width="2012" height="1290" alt="image" src="https://github.com/user-attachments/assets/8bd9f321-dfd1-4319-855b-ea56fb75583b" />

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] local / postman
- [x] 시나리오 기반 테스트 유무


---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서
