### PR TITLE
Feat/rank 랭킹 페이지 조회 API 구현

### DIFF
--- a/src/main/java/_team/earnedit/controller/RankController.java
+++ b/src/main/java/_team/earnedit/controller/RankController.java
@@ -31,9 +31,7 @@ public class RankController {
             @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
 
         long userId = userInfoDto.getUserId();
-
-        RankPageResponse rankPage = (RankPageResponse) rankService.getRankPage(userId);
-
+        RankPageResponse rankPage = rankService.getRankPage(userId);
 
         return ResponseEntity.ok(ApiResponse.success("랭킹 정보를 조회했습니다.", rankPage));
     }

--- a/src/main/java/_team/earnedit/controller/RankController.java
+++ b/src/main/java/_team/earnedit/controller/RankController.java
@@ -1,0 +1,40 @@
+package _team.earnedit.controller;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.dto.rank.RankPageResponse;
+import _team.earnedit.global.ApiResponse;
+import _team.earnedit.service.RankService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rank")
+@Tag(name = "Rank", description = "Rank API")
+public class RankController {
+
+    private final RankService rankService;
+
+    @GetMapping
+    @Operation(summary = "랭킹 페이지 조회",
+            description = "랭킹 페이지의 정보를 조회합니다 \n" +
+                    "내 랭크 정보, top10 정보 조회",
+            security = {@SecurityRequirement(name = "bearer-key")})
+    public ResponseEntity<ApiResponse<RankPageResponse>> getRankPage(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto) {
+
+        long userId = userInfoDto.getUserId();
+
+        RankPageResponse rankPage = (RankPageResponse) rankService.getRankPage(userId);
+
+
+        return ResponseEntity.ok(ApiResponse.success("랭킹 정보를 조회했습니다.", rankPage));
+    }
+}

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -182,6 +182,25 @@ public class WishController {
         return ResponseEntity.ok(ApiResponse.success("검색 결과입니다.", result));
     }
 
+    @GetMapping("/main")
+    @Operation(
+            summary = "위시 통합조회",
+            description = "위시 페이지 렌더링 시, 유저 목록, star리스트, \n" +
+                    "위시리스트(3개)\n" +
+                    "내 정보를 모두 조회합니다",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<FetchWishPageResponse>> fetchWishPage(
+            @AuthenticationPrincipal JwtUserInfoDto userInfo,
+            @RequestParam long userCount
+    ) {
+        FetchWishPageResponse response = wishService.fetchWishPage(userInfo.getUserId(), userCount);
+
+        return ResponseEntity.ok(ApiResponse.success("위시 하이라이트를 조회하였습니다.", response));
+
+    }
+
+
 
 
 

--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -196,7 +196,7 @@ public class WishController {
     ) {
         FetchWishPageResponse response = wishService.fetchWishPage(userInfo.getUserId(), userCount);
 
-        return ResponseEntity.ok(ApiResponse.success("위시 하이라이트를 조회하였습니다.", response));
+        return ResponseEntity.ok(ApiResponse.success("위시 페이지 통합 조회 성공.", response));
 
     }
 

--- a/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
+++ b/src/main/java/_team/earnedit/dto/puzzle/PuzzleResponse.java
@@ -93,5 +93,8 @@ public class PuzzleResponse {
         @Schema(description = "전체 누적 금액(원)", example = "33330")
         private long totalAccumulatedValue;
 
+        @Schema(description = "유저의 랭킹", example = "1")
+        private long rank;
+
     }
 }

--- a/src/main/java/_team/earnedit/dto/rank/RankPageResponse.java
+++ b/src/main/java/_team/earnedit/dto/rank/RankPageResponse.java
@@ -8,17 +8,6 @@ import java.util.List;
 @Getter
 @Builder
 public class RankPageResponse {
-
     private UserRankInfo myRank;
     private List<UserRankInfo> top10;
-
-    @Getter
-    @Builder
-    private static class UserRankInfo {
-        private long userId;
-        private int rank;
-        private String nickname;
-        private long score;
-        private String profileImage;
-    }
 }

--- a/src/main/java/_team/earnedit/dto/rank/RankPageResponse.java
+++ b/src/main/java/_team/earnedit/dto/rank/RankPageResponse.java
@@ -1,0 +1,24 @@
+package _team.earnedit.dto.rank;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RankPageResponse {
+
+    private UserRankInfo myRank;
+    private List<UserRankInfo> top10;
+
+    @Getter
+    @Builder
+    private static class UserRankInfo {
+        private long userId;
+        private int rank;
+        private String nickname;
+        private long score;
+        private String profileImage;
+    }
+}

--- a/src/main/java/_team/earnedit/dto/rank/UserRankInfo.java
+++ b/src/main/java/_team/earnedit/dto/rank/UserRankInfo.java
@@ -1,0 +1,23 @@
+package _team.earnedit.dto.rank;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserRankInfo {
+    private long userId;
+    private long rank;
+    private String nickname;
+    private long score;
+    private String profileImage;
+
+    // JPA 네이티브 쿼리 매핑용 생성자
+    public UserRankInfo(long userId, long rank, String nickname, long score, String profileImage) {
+        this.userId = userId;
+        this.rank = rank;
+        this.nickname = nickname;
+        this.score = score;
+        this.profileImage = profileImage;
+    }
+}

--- a/src/main/java/_team/earnedit/dto/wish/FetchWishPageResponse.java
+++ b/src/main/java/_team/earnedit/dto/wish/FetchWishPageResponse.java
@@ -1,0 +1,19 @@
+package _team.earnedit.dto.wish;
+
+import _team.earnedit.dto.profile.ProfileInfoResponseDto;
+import _team.earnedit.dto.profile.PublicUserInfoResponse;
+import _team.earnedit.dto.star.StarSummaryResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class FetchWishPageResponse {
+
+    ProfileInfoResponseDto userInfo;
+    List<PublicUserInfoResponse> userList;
+    List<StarSummaryResponse> starList;
+    List<WishDetailResponse> wishList;
+}

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -78,6 +78,9 @@ public class User {
     @Column(nullable = false)
     private Boolean isCheckedIn = false;
 
+    @Column(nullable = false)
+    private long score = 0L;
+
     public void softDeleted() {
         this.status = Status.DELETED;
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -39,4 +39,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query(value = "SELECT * FROM users WHERE is_public = true ORDER BY RANDOM() LIMIT :count", nativeQuery = true)
     List<User> findRandomPublicUsers(@Param("count") long count);
+
+    // 로그인한 유저 id를 제외한 유저 리스트를 반환
+    @Query(value = "SELECT * FROM users " +
+            "WHERE is_public = true AND id <> :userId " +
+            "ORDER BY RANDOM() LIMIT :count", nativeQuery = true)
+    List<User> findRandomPublicUsersExcept(@Param("userId") Long userId,
+                                           @Param("count") long count);
 }

--- a/src/main/java/_team/earnedit/repository/UserRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package _team.earnedit.repository;
 
+import _team.earnedit.dto.rank.UserRankInfo;
 import _team.earnedit.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -46,4 +47,36 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "ORDER BY RANDOM() LIMIT :count", nativeQuery = true)
     List<User> findRandomPublicUsersExcept(@Param("userId") Long userId,
                                            @Param("count") long count);
+
+
+    /***
+     * Rank() : 같은 점수면 같은 순위, 다음 순위는 건너뜀(1, 2, 2, 4 ...)
+     * DENSE_RANK() : 같은 점수면 같은 순위, 순위 건너뛰지 않음(1, 2, 2, 3 ...)
+     * ROW_NUMBER() : 무조건 고유 순위(1, 2, 3, 4 ...)
+     */
+    @Query(value = """
+            SELECT u.id AS userId,
+                   ROW_NUMBER() OVER (ORDER BY u.score DESC) AS rank,
+                   u.nickname AS nickname,
+                   u.score AS score,
+                   u.profile_image AS profileImage
+            FROM users u
+            WHERE u.status = 'ACTIVE'
+            LIMIT 10
+            """, nativeQuery = true)
+    List<UserRankInfo> findTop10UsersWithRanking();
+
+
+    @Query(value = """
+            SELECT ranked.ranking
+            FROM (
+                SELECT u.id,
+                       ROW_NUMBER() OVER (ORDER BY u.score DESC) AS ranking
+                FROM users u
+                WHERE u.status = 'ACTIVE'
+            ) ranked
+            WHERE ranked.id = :userId
+            """, nativeQuery = true)
+    int findUserRanking(@Param("userId") Long userId);
+
 }

--- a/src/main/java/_team/earnedit/service/PuzzleService.java
+++ b/src/main/java/_team/earnedit/service/PuzzleService.java
@@ -10,6 +10,7 @@ import _team.earnedit.mapper.PieceMapper;
 import _team.earnedit.mapper.PuzzleMapper;
 import _team.earnedit.repository.PieceRepository;
 import _team.earnedit.repository.PuzzleSlotRepository;
+import _team.earnedit.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class PuzzleService {
     private final EntityFinder entityFinder;
     private final PieceMapper pieceMapper;
     private final PuzzleMapper puzzleMapper;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public PuzzleResponse getPuzzle(Long userId) {
@@ -55,7 +57,7 @@ public class PuzzleService {
         }
 
         // 2. 요약값 계산
-        Summary summary = computeSummary(slots, pieces, themeSlotMap, collectedCountMap, totalValueMap);
+        Summary summary = computeSummary(slots, pieces, themeSlotMap, collectedCountMap, totalValueMap, userId);
 
         // 3. 퍼즐 요약 정보
         PuzzleResponse.PuzzleInfo puzzleInfo = getPuzzleInfo(summary);
@@ -77,6 +79,7 @@ public class PuzzleService {
                 .totalPieceCount(summary.totalPieceCount)
                 .completedPieceCount(summary.completedPieceCount)
                 .totalAccumulatedValue(summary.totalAccumulatedValue)
+                .rank(summary.rank)
                 .build();
     }
 
@@ -124,7 +127,8 @@ public class PuzzleService {
             List<Piece> pieces,
             Map<Theme, List<PuzzleResponse.SlotInfo>> themeSlotMap,
             Map<Theme, Integer> collectedCountMap,
-            Map<Theme, Long> totalValueMap
+            Map<Theme, Long> totalValueMap,
+            long userId
     ) {
         int totalPieceCount = slots.size();
         int completedPieceCount = (int) pieces.stream().filter(Piece::isCollected).count();
@@ -145,12 +149,15 @@ public class PuzzleService {
                     return total > 0 && collected == total;
                 }).count();
 
+        long rank = userRepository.findUserRanking(userId);
+
         return new Summary(
                 (int) themeCount,
                 completedThemeCount,
                 totalPieceCount,
                 completedPieceCount,
-                totalAccumulatedValue
+                totalAccumulatedValue,
+                rank
         );
     }
 
@@ -196,7 +203,8 @@ public class PuzzleService {
             int completedThemeCount,
             int totalPieceCount,
             int completedPieceCount,
-            long totalAccumulatedValue
+            long totalAccumulatedValue,
+            long rank
     ) {}
 
 }

--- a/src/main/java/_team/earnedit/service/RankService.java
+++ b/src/main/java/_team/earnedit/service/RankService.java
@@ -1,0 +1,19 @@
+package _team.earnedit.service;
+
+import _team.earnedit.dto.rank.RankPageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RankService {
+
+    public RankPageResponse getRankPage(long userId) {
+
+
+
+        return null;
+    }
+}

--- a/src/main/java/_team/earnedit/service/RankService.java
+++ b/src/main/java/_team/earnedit/service/RankService.java
@@ -1,19 +1,54 @@
 package _team.earnedit.service;
 
 import _team.earnedit.dto.rank.RankPageResponse;
+import _team.earnedit.dto.rank.UserRankInfo;
+import _team.earnedit.entity.User;
+import _team.earnedit.global.util.EntityFinder;
+import _team.earnedit.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RankService {
 
+    private final EntityFinder entityFinder;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
     public RankPageResponse getRankPage(long userId) {
+        User user = entityFinder.getUserOrThrow(userId);
 
+        // 내 랭킹 정보
+        int myRank = userRepository.findUserRanking(user.getId());
 
+        UserRankInfo myRankInfo = UserRankInfo.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .score(user.getScore())
+                .profileImage(user.getProfileImage())
+                .rank(myRank)
+                .build();
 
-        return null;
+        // top10 유저들의 랭킹 정보
+        List<UserRankInfo> top10 = userRepository.findTop10UsersWithRanking().stream()
+                .map(sel_user -> UserRankInfo.builder()
+                        .userId(sel_user.getUserId())
+                        .nickname(sel_user.getNickname())
+                        .score(sel_user.getScore())
+                        .profileImage(sel_user.getProfileImage())
+                        .rank(sel_user.getRank())
+                        .build())
+                .toList();
+
+        return RankPageResponse.builder()
+                .myRank(myRankInfo)
+                .top10(top10)
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 랭킹 페이지 조회 API 구현 및 기존 퍼즐 정보 조회 API 에 rank 응답 추가

---

## ✨ 주요 변경 사항
- 랭킹 페이지 조회 API 구현
- 퍼즐 정보 조회 API에 rank 응답 추가
- User테이블에 score 필드 추가

---

## 🖼️ 기능 살펴 보기
> <img width="1429" height="868" alt="스크린샷 2025-09-02 오전 11 46 32" src="https://github.com/user-attachments/assets/add5c819-fdee-4062-9e41-a3d150fc06cd" />
- 기존 퍼즐 정보 조회 API 에 rank 필드 추가

> <img width="1438" height="1011" alt="image" src="https://github.com/user-attachments/assets/2b6b4521-a49a-4012-8779-c1ae159f4ee6" />
- 랭킹 페이지 조회 API 정상 동작
- top10의 경우 순위 순서대로 출력 


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI 

---

## 💬 기타 참고 사항
- ****** 반영 완료 후, 운영 DB에 수동으로 User.score 추가 필요. *******

---

## 📎 관련 이슈 / 문서

