### PR TITLE
Feat/report : 공개범위 전환 api, 타유저신고api (신고남용방지 로직)

### DIFF
--- a/src/main/java/_team/earnedit/controller/ProfileController.java
+++ b/src/main/java/_team/earnedit/controller/ProfileController.java
@@ -9,6 +9,7 @@ import _team.earnedit.service.TermService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -131,4 +132,18 @@ public class ProfileController {
                 .body(ApiResponse.success("프로필 이미지가 삭제되었습니다."));
     }
 
+    @Operation(
+            summary = "프로필 공개범위 변경",
+            description = "사용자의 프로필 공개범위를 변경합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @PatchMapping("/visibility")
+    public ResponseEntity<ApiResponse<Void>> updateVisibility(
+            @Valid @RequestBody UpdateVisibilityRequestDto request,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto)
+    {
+        profileService.updateVisibility(userInfoDto.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("프로필 공개 범위를 변경했습니다."));
+    }
 }

--- a/src/main/java/_team/earnedit/controller/ReportController.java
+++ b/src/main/java/_team/earnedit/controller/ReportController.java
@@ -1,0 +1,37 @@
+package _team.earnedit.controller;
+
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.dto.report.ReportUserRequestDto;
+import _team.earnedit.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import _team.earnedit.service.ReportService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(
+            summary = "타 유저 신고",
+            description = "타 유저의 프로필/닉네임/위시 등을 신고합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") }
+    )
+    @PostMapping("/user")
+    public ResponseEntity<ApiResponse<Void>> reportUser(
+            @Valid @RequestBody ReportUserRequestDto request,
+            @AuthenticationPrincipal JwtUserInfoDto me
+    ) {
+        reportService.reportUser(me.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("신고가 접수되었습니다."));
+    }
+}

--- a/src/main/java/_team/earnedit/dto/profile/UpdateVisibilityRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/profile/UpdateVisibilityRequestDto.java
@@ -1,0 +1,14 @@
+package _team.earnedit.dto.profile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "프로필 공개범위 변경 요청 DTO")
+public class UpdateVisibilityRequestDto {
+
+    @NotNull
+    @Schema(description = "프로필 공개 여부 (true=공개, false=비공개)", example = "true")
+    private Boolean isPublic;
+}

--- a/src/main/java/_team/earnedit/dto/report/ReportUserRequestDto.java
+++ b/src/main/java/_team/earnedit/dto/report/ReportUserRequestDto.java
@@ -1,0 +1,26 @@
+package _team.earnedit.dto.report;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "타 유저 신고 요청 DTO")
+public class ReportUserRequestDto {
+
+    @NotNull
+    @Schema(description = "신고 대상 유저 ID", example = "123")
+    private Long reportedUserId;
+
+    @NotBlank
+    @Schema(description = "신고 사유 코드 (report_reason.code)", example = "INAPPROPRIATE_PROFILE")
+    private String reasonCode;
+
+    @Size(max = 500)
+    @Schema(description = "직접 입력 사유(기타 선택 시 필수)", example = "프로필 문구에 부적절한 표현이 있어요")
+    private String reasonText;
+}

--- a/src/main/java/_team/earnedit/entity/ReportReason.java
+++ b/src/main/java/_team/earnedit/entity/ReportReason.java
@@ -1,8 +1,7 @@
 package _team.earnedit.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -10,7 +9,9 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "report_reason")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ReportReason {
 
     @Id

--- a/src/main/java/_team/earnedit/entity/ReportReason.java
+++ b/src/main/java/_team/earnedit/entity/ReportReason.java
@@ -1,0 +1,29 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_reason")
+@Getter
+@NoArgsConstructor
+public class ReportReason {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(name = "description", nullable = false, length = 255)
+    private String description;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -95,6 +95,8 @@ public class User {
         this.profileImage = imageUrl;
     }
 
+    public void updateVisibility(boolean isPublic) { this.isPublic = isPublic; }
+
     public void checkIn() { ////////////// 동훈님 코드에서 사용하십시오 ~
         this.isCheckedIn = true;
     }

--- a/src/main/java/_team/earnedit/entity/UserReport.java
+++ b/src/main/java/_team/earnedit/entity/UserReport.java
@@ -1,0 +1,39 @@
+package _team.earnedit.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_report")
+@Getter
+@NoArgsConstructor
+public class UserReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reporting_user_id", nullable = false)
+    private User reportingUser; // 신고자
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser; // 신고 대상
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reason_id", nullable = false)
+    private ReportReason reason; // 신고 사유
+
+    @Column(name = "reason_text", length = 500)
+    private String reasonText;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/_team/earnedit/entity/UserReport.java
+++ b/src/main/java/_team/earnedit/entity/UserReport.java
@@ -1,8 +1,7 @@
 package _team.earnedit.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -10,7 +9,9 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "user_report")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class UserReport {
 
     @Id

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
     REASON_TEXT_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유는 상세 사유를 입력해야 합니다."),
     CANNOT_REPORT_SELF(HttpStatus.CONFLICT, "자기 자신을 신고할 수 없습니다."),
     REPORT_DUPLICATE(HttpStatus.CONFLICT, "동일 대상에 대한 신고가 이미 접수되었습니다."),
+    REPORT_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
 
     // 파일 업로드
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다."),

--- a/src/main/java/_team/earnedit/global/ErrorCode.java
+++ b/src/main/java/_team/earnedit/global/ErrorCode.java
@@ -83,6 +83,12 @@ public enum ErrorCode {
     PASSWORD_SAME_AS_BEFORE(HttpStatus.BAD_REQUEST, "이전 비밀번호와 동일합니다."),
     INVALID_LOGIN_PROVIDER(HttpStatus.BAD_REQUEST, "이메일 로그인 계정이 아닙니다."),
 
+    // 신고 Report
+    REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "유효한 신고 사유가 아닙니다."),
+    REASON_TEXT_REQUIRED(HttpStatus.BAD_REQUEST, "기타 사유는 상세 사유를 입력해야 합니다."),
+    CANNOT_REPORT_SELF(HttpStatus.CONFLICT, "자기 자신을 신고할 수 없습니다."),
+    REPORT_DUPLICATE(HttpStatus.CONFLICT, "동일 대상에 대한 신고가 이미 접수되었습니다."),
+
     // 파일 업로드
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다."),
 

--- a/src/main/java/_team/earnedit/global/exception/report/ReportException.java
+++ b/src/main/java/_team/earnedit/global/exception/report/ReportException.java
@@ -1,0 +1,18 @@
+package _team.earnedit.global.exception.report;
+
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+
+public class ReportException extends CustomException {
+    private final ErrorCode errorCode;
+
+    public ReportException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    public ReportException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, errorCode.getDefaultMessage() + " " + customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/_team/earnedit/repository/ReportReasonRepository.java
+++ b/src/main/java/_team/earnedit/repository/ReportReasonRepository.java
@@ -3,6 +3,9 @@ package _team.earnedit.repository;
 import _team.earnedit.entity.ReportReason;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReportReasonRepository extends JpaRepository<ReportReason, Long> {
 
+    Optional<ReportReason> findByCode(String code);
 }

--- a/src/main/java/_team/earnedit/repository/ReportReasonRepository.java
+++ b/src/main/java/_team/earnedit/repository/ReportReasonRepository.java
@@ -1,0 +1,8 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.ReportReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportReasonRepository extends JpaRepository<ReportReason, Long> {
+
+}

--- a/src/main/java/_team/earnedit/repository/UserReportRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserReportRepository.java
@@ -1,0 +1,8 @@
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.UserReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserReportRepository extends JpaRepository<UserReport, Long> {
+
+}

--- a/src/main/java/_team/earnedit/repository/UserReportRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserReportRepository.java
@@ -10,4 +10,8 @@ public interface UserReportRepository extends JpaRepository<UserReport, Long> {
     boolean existsByReportingUser_IdAndReportedUser_IdAndCreatedAtAfter(
             Long reportingUserId, Long reportedUserId, LocalDateTime createdAfter
     );
+
+    long countByReportingUser_IdAndCreatedAtAfter(
+            Long reportingUserId, LocalDateTime createdAfter
+    );
 }

--- a/src/main/java/_team/earnedit/repository/UserReportRepository.java
+++ b/src/main/java/_team/earnedit/repository/UserReportRepository.java
@@ -3,6 +3,11 @@ package _team.earnedit.repository;
 import _team.earnedit.entity.UserReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface UserReportRepository extends JpaRepository<UserReport, Long> {
 
+    boolean existsByReportingUser_IdAndReportedUser_IdAndCreatedAtAfter(
+            Long reportingUserId, Long reportedUserId, LocalDateTime createdAfter
+    );
 }

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -1,9 +1,6 @@
 package _team.earnedit.service;
 
-import _team.earnedit.dto.profile.NicknameRequestDto;
-import _team.earnedit.dto.profile.ProfileInfoResponseDto;
-import _team.earnedit.dto.profile.SalaryRequestDto;
-import _team.earnedit.dto.profile.SalaryResponseDto;
+import _team.earnedit.dto.profile.*;
 import _team.earnedit.entity.Salary;
 import _team.earnedit.entity.User;
 import _team.earnedit.global.ErrorCode;
@@ -123,6 +120,14 @@ public class ProfileService {
         User user = entityFinder.getUserOrThrow(userId);
 
         user.updateProfileImage(null);
+    }
+
+    // 프로필 공개범위 설정
+    @Transactional
+    public void updateVisibility(Long userId, UpdateVisibilityRequestDto requestDto) {
+        User user = entityFinder.getUserOrThrow(userId);
+
+        user.updateVisibility(requestDto.getIsPublic());
     }
 
 }

--- a/src/main/java/_team/earnedit/service/ReportService.java
+++ b/src/main/java/_team/earnedit/service/ReportService.java
@@ -1,0 +1,55 @@
+package _team.earnedit.service;
+
+import _team.earnedit.dto.report.ReportUserRequestDto;
+import _team.earnedit.entity.ReportReason;
+import _team.earnedit.entity.User;
+import _team.earnedit.entity.UserReport;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.report.ReportException;
+import _team.earnedit.global.util.EntityFinder;
+import _team.earnedit.repository.ReportReasonRepository;
+import _team.earnedit.repository.UserReportRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportService {
+
+    private final ReportReasonRepository reportReasonRepository;
+    private final UserReportRepository userReportRepository;
+    private final EntityFinder entityFinder;
+
+    public void reportUser(Long reportingUserId, ReportUserRequestDto dto) {
+        User reportingUser = entityFinder.getUserOrThrow(reportingUserId);
+        User reportedUser  = entityFinder.getUserOrThrow(dto.getReportedUserId());
+
+        if (reportingUser.getId().equals(reportedUser.getId())) {
+            throw new ReportException(ErrorCode.CANNOT_REPORT_SELF);
+        }
+
+        ReportReason reason = reportReasonRepository.findByCode(dto.getReasonCode())
+                .orElseThrow(() -> new ReportException(ErrorCode.REASON_NOT_FOUND));
+
+        // 기타 사유일 때 상세사유 입력 필수
+        if ("OTHER".equals(reason.getCode())) {
+            if (dto.getReasonText() == null || dto.getReasonText().isBlank()) {
+                throw new ReportException(ErrorCode.REASON_TEXT_REQUIRED);
+            }
+        }
+
+        UserReport report = UserReport.builder()
+                .reportingUser(reportingUser)
+                .reportedUser(reportedUser)
+                .reason(reason)
+                .reasonText(dto.getReasonText())
+                .build();
+
+        userReportRepository.save(report);
+    }
+}
+


### PR DESCRIPTION
## 📌 작업 개요
- 공개범위 전환 api, 타유저신고api (신고남용방지 로직)

---

## ✨ 주요 변경 사항
- Entity, 각 repository 추가
  - Report_Reason
  - User_Report
- Report 기능 관련 파일 추가
  - service, controller, custom exception, dtos ...


- reportUser 서비스 / 컨트롤러 메서드 구현
  - 2단계 신고남용 방지 -> 예외처리
- updateVisibility 서비스 / 컨트롤러 메서드 구현
  - User 엔티티에 update 도메인메서드 설정 후 이용


---

## 🖼️ 기능 살펴 보기
> 공개범위 전환 api
<img width="2040" height="1436" alt="image" src="https://github.com/user-attachments/assets/22aed98d-4b79-49af-9f57-e5d7c7387b83" />
<img width="2282" height="380" alt="image" src="https://github.com/user-attachments/assets/622b395d-bb95-4def-883b-d931a683919d" />

> 타유저 신고 api : 성공
<img width="1716" height="1252" alt="image" src="https://github.com/user-attachments/assets/c120d958-3694-48f1-8cd0-7b42c6a4a0a8" />
<img width="2186" height="440" alt="image" src="https://github.com/user-attachments/assets/1fbf45da-35f5-4e44-ae0d-68542cf5cbe3" />


> 타유저 신고 api : 예외 예시 1
<img width="1718" height="1156" alt="image" src="https://github.com/user-attachments/assets/216d7a4a-d56c-418c-b295-e43782a45198" />

> 타유저 신고 api : 예외 예시 2
<img width="1716" height="1160" alt="image" src="https://github.com/user-attachments/assets/41060c41-dae3-4038-a450-b26357cd3e0e" />


> 신고이유 테이블
<img width="1386" height="618" alt="image" src="https://github.com/user-attachments/assets/5aac5a33-e338-491a-9945-ec8b0c03d8d4" />

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [x] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] postman local
- [x] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 머지 이후 db에 신고사유-코드 넣어줘야 이용 가능함

---

## 📎 관련 이슈 / 문서

