### PR TITLE
Bug/user-profile 프론트 요청사항 추가(유저 프로필 조회에 초당수익, payday추가)

### DIFF
--- a/src/main/java/_team/earnedit/dto/profile/OtherUserProfileResponse.java
+++ b/src/main/java/_team/earnedit/dto/profile/OtherUserProfileResponse.java
@@ -1,0 +1,28 @@
+package _team.earnedit.dto.profile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "프로필 정보 응답 DTO")
+public class OtherUserProfileResponse {
+    @Schema(description = "유저 id", example = "1")
+    private long userId;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://s3.../profile.png")
+    private String profileImage;
+
+    @Schema(description = "사용자 닉네임", example = "요림짱")
+    private String nickname;
+
+    @Schema(description = "월 수익 (단위: 원)", example = "4000000")
+    private Long monthlySalary;
+
+    @Schema(description = "초당 수익(단위: 원)", example = "0.02")
+    private double amountPerSec;
+
+    @Schema(description = "월급 날짜", example = "2")
+    private long payday;
+}

--- a/src/main/java/_team/earnedit/dto/profile/ProfileWithStarResponse.java
+++ b/src/main/java/_team/earnedit/dto/profile/ProfileWithStarResponse.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Getter
 public class ProfileWithStarResponse {
 
-    ProfileInfoResponseDto userInfo;
+    OtherUserProfileResponse userInfo;
     List<StarSummaryResponse> starList;
 }

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -151,11 +151,13 @@ public class ProfileService {
 
         Salary salary = entityFinder.getSalaryOrThrow(userId);
 
-        ProfileInfoResponseDto userInfo = ProfileInfoResponseDto.builder()
+        OtherUserProfileResponse userInfo = OtherUserProfileResponse.builder()
                 .userId(findUser.getId())
                 .nickname(findUser.getNickname())
                 .profileImage(findUser.getProfileImage())
                 .monthlySalary(salary.getAmount())
+                .amountPerSec(salary.getAmountPerSec())
+                .payday(salary.getPayday())
                 .build();
 
         List<StarSummaryResponse> starSummaryList = starList.stream()


### PR DESCRIPTION
## 📌 작업 개요
- 프론트 요청사항 추가(유저 프로필 조회에 초당수익, payday추가)

---

## ✨ 주요 변경 사항
- 프론트 요청사항 추가(유저 프로필 조회에 초당수익, payday추가)
- OtherUserProfileResponse 응답객체 추가
- 월급 정보가 제대로 반영되지 않던 문제 수정

---

## 🖼️ 기능 살펴 보기
> <img width="1291" height="402" alt="image" src="https://github.com/user-attachments/assets/04f0f45d-4f70-48d1-b5a8-10b1d8490592" />
- 테스트 완료

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법

---

## 💬 기타 참고 사항
- 프론트측 요청사항 처리

---

## 📎 관련 이슈 / 문서
