### PR TITLE
bug : 상품 검색 API 복구 및 API 요청 형식 변경

### DIFF
--- a/src/main/java/_team/earnedit/controller/ProductController.java
+++ b/src/main/java/_team/earnedit/controller/ProductController.java
@@ -1,41 +1,57 @@
-//package _team.earnedit.controller;
-//
-//import _team.earnedit.dto.item.NaverProductSearchRequest;
-//import _team.earnedit.dto.item.ProductSearchResponse;
-//import _team.earnedit.dto.jwt.JwtUserInfoDto;
-//import _team.earnedit.global.ApiResponse;
-//import _team.earnedit.service.ProductService;
-//import io.swagger.v3.oas.annotations.Operation;
-//import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-//import io.swagger.v3.oas.annotations.tags.Tag;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
-//import org.springframework.web.bind.annotation.*;
-//
-//import jakarta.validation.Valid;
-//
-//@Slf4j
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/api/v1/products")
-//@Tag(name = "Product", description = "상품 검색 API")
-//public class ProductController {
-//
-//    private final ProductService productService;
-//
-//    @GetMapping("/search")
-//    @Operation(
-//            summary = "상품 검색",
-//            description = "네이버 쇼핑 API를 통해 상품을 검색합니다. 이미지 자동 저장 및 배경 제거 기능을 제공합니다.",
-//            security = {@SecurityRequirement(name = "bearer-key")}
-//    )
-//    public ResponseEntity<ApiResponse<ProductSearchResponse>> searchProducts(
-//            @AuthenticationPrincipal JwtUserInfoDto userInfoDto,
-//            @Valid @ModelAttribute NaverProductSearchRequest request
-//    ) {
-//        ProductSearchResponse result = productService.searchProducts(request);
-//        return ResponseEntity.ok(ApiResponse.success("상품 검색이 완료되었습니다.", result));
-//    }
-//}
+package _team.earnedit.controller;
+
+import _team.earnedit.dto.item.NaverProductSearchRequest;
+import _team.earnedit.dto.item.ProductSearchResponse;
+import _team.earnedit.dto.jwt.JwtUserInfoDto;
+import _team.earnedit.global.ApiResponse;
+import _team.earnedit.service.ProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+@Tag(name = "Product", description = "상품 검색 API")
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "상품 검색",
+            description = "네이버 쇼핑 API를 통해 상품을 검색합니다. 이미지 자동 저장 및 배경 제거 기능을 제공합니다.",
+            security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    public ResponseEntity<ApiResponse<ProductSearchResponse>> searchProducts(
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto,
+            @Parameter(description = "검색어", required = true, example = "아이폰 14")
+            @RequestParam String query,
+
+            @Parameter(description = "캐시 사용 여부", example = "true")
+            @RequestParam(defaultValue = "true") Boolean useCache,
+
+            @Parameter(description = "이미지 배경 제거 여부 (향후 구현 예정)", example = "false")
+            @RequestParam(defaultValue = "false") Boolean removeBackground,
+
+            @Parameter(description = "검색 결과 개수 (최대 100)", example = "20")
+            @RequestParam(defaultValue = "20") Integer display
+    ) {
+        NaverProductSearchRequest request = NaverProductSearchRequest.builder()
+                .query(query.trim())
+                .useCache(useCache)
+                .removeBackground(removeBackground)
+                .display(display)
+                .build();
+
+        ProductSearchResponse result = productService.searchProducts(request);
+        return ResponseEntity.ok(ApiResponse.success("상품 검색이 완료되었습니다.", result));
+    }
+}

--- a/src/main/java/_team/earnedit/dto/item/NaverProductSearchRequest.java
+++ b/src/main/java/_team/earnedit/dto/item/NaverProductSearchRequest.java
@@ -24,18 +24,15 @@ public class NaverProductSearchRequest {
     private String query;
     
     @Schema(description = "캐시 사용 여부", example = "true")
-    @Builder.Default
-    private Boolean useCache = true;
+    private Boolean useCache;
     
     @Schema(description = "이미지 배경 제거 여부 (향후 구현 예정)", example = "false")
-    @Builder.Default
-    private Boolean removeBackground = false;
+    private Boolean removeBackground;
     
     @Schema(description = "검색 결과 개수 (1-100)", example = "20")
     @Min(value = 1, message = "검색 결과 개수는 1 이상이어야 합니다.")
     @Max(value = 100, message = "검색 결과 개수는 100 이하여야 합니다.")
-    @Builder.Default
-    private Integer display = 20;
+    private Integer display;
     
     @JsonIgnore
     public Integer getStart() {

--- a/src/main/java/_team/earnedit/dto/main/MainPageResponse.java
+++ b/src/main/java/_team/earnedit/dto/main/MainPageResponse.java
@@ -41,5 +41,8 @@ public class MainPageResponse {
 
         @Schema(description = "출석체크 여부")
         private boolean isCheckedIn;
+
+        @Schema(description = "프로필 공개 여부")
+        private boolean isPublic;
     }
 }

--- a/src/main/java/_team/earnedit/entity/User.java
+++ b/src/main/java/_team/earnedit/entity/User.java
@@ -108,4 +108,23 @@ public class User {
         this.isCheckedIn = false;
     }
 
+    public void addScore(long score) {
+        this.score += score;
+    }
+//    public void checkedInReward() {
+//        this.score += 10;
+//    }
+//    public void reward_S () {
+//        this.score += 10;
+//    }
+//    public void reward_A () {
+//        this.score += 7;
+//    }
+//    public void reward_B () {
+//        this.score += 5;
+//    }
+//    // 퍼즐 테마 완성 시 100 지급
+//    public void reward_CompleteTheme() {
+//        this.score+=100;
+//    }
 }

--- a/src/main/java/_team/earnedit/mapper/MainPageMapper.java
+++ b/src/main/java/_team/earnedit/mapper/MainPageMapper.java
@@ -32,6 +32,7 @@ public interface MainPageMapper {
     @Mapping(target = "payday", source = "salary.payday", defaultValue = "0")
     @Mapping(target = "hasSalary", expression = "java(salary != null)")
     @Mapping(target = "isCheckedIn", source = "user.isCheckedIn")
+    @Mapping(target = "isPublic", source = "user.isPublic")
     MainPageResponse.UserInfo toUserInfo(User user, Salary salary);
 
     // Wish → WishListResponse

--- a/src/main/java/_team/earnedit/repository/PuzzleSlotRepository.java
+++ b/src/main/java/_team/earnedit/repository/PuzzleSlotRepository.java
@@ -1,5 +1,6 @@
 package _team.earnedit.repository;
 
+import _team.earnedit.entity.Item;
 import _team.earnedit.entity.PuzzleSlot;
 import _team.earnedit.entity.Theme;
 import io.lettuce.core.dynamic.annotation.Param;
@@ -20,4 +21,6 @@ public interface PuzzleSlotRepository extends JpaRepository<PuzzleSlot, Long> {
     void deleteByItemId(@Param("itemId") Long itemId);
 
     List<PuzzleSlot> findByTheme(Theme theme);
+
+    PuzzleSlot findByItem(Item item);
 }

--- a/src/main/java/_team/earnedit/repository/SearchItemRepository.java
+++ b/src/main/java/_team/earnedit/repository/SearchItemRepository.java
@@ -1,21 +1,21 @@
-//package _team.earnedit.repository;
-//
-//import _team.earnedit.entity.SearchItem;
-//import org.springframework.data.jpa.repository.JpaRepository;
-//import org.springframework.data.jpa.repository.Query;
-//import org.springframework.data.repository.query.Param;
-//
-//import java.util.List;
-//
-//public interface SearchItemRepository extends JpaRepository<SearchItem, Long> {
-//
-//    // productId로 검색
-//    SearchItem findByProductId(String productId);
-//
-//    // productId 존재 여부 확인
-//    boolean existsByProductId(String productId);
-//
-//    // 이름으로 검색 (캐시 조회용)
-//    @Query("SELECT s FROM SearchItem s WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :query, '%')) ORDER BY s.id DESC")
-//    List<SearchItem> findByNameContainingIgnoreCase(@Param("query") String query);
-//}
+package _team.earnedit.repository;
+
+import _team.earnedit.entity.SearchItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SearchItemRepository extends JpaRepository<SearchItem, Long> {
+
+    // productId로 검색
+    SearchItem findByProductId(String productId);
+
+    // productId 존재 여부 확인
+    boolean existsByProductId(String productId);
+
+    // 이름으로 검색 (캐시 조회용)
+    @Query("SELECT s FROM SearchItem s WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :query, '%')) ORDER BY s.id DESC")
+    List<SearchItem> findByNameContainingIgnoreCase(@Param("query") String query);
+}

--- a/src/main/java/_team/earnedit/service/DailyCheckService.java
+++ b/src/main/java/_team/earnedit/service/DailyCheckService.java
@@ -4,9 +4,7 @@ import _team.earnedit.dto.dailyCheck.RewardCandidate;
 import _team.earnedit.dto.dailyCheck.RewardItem;
 import _team.earnedit.dto.dailyCheck.RewardSelectionRequest;
 import _team.earnedit.dto.puzzle.PieceResponse;
-import _team.earnedit.entity.Item;
-import _team.earnedit.entity.Piece;
-import _team.earnedit.entity.User;
+import _team.earnedit.entity.*;
 import _team.earnedit.global.ErrorCode;
 import _team.earnedit.global.exception.item.ItemException;
 import _team.earnedit.global.exception.user.UserException;
@@ -14,6 +12,7 @@ import _team.earnedit.global.util.EntityFinder;
 import _team.earnedit.mapper.PieceMapper;
 import _team.earnedit.repository.ItemRepository;
 import _team.earnedit.repository.PieceRepository;
+import _team.earnedit.repository.PuzzleSlotRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -41,6 +42,7 @@ public class DailyCheckService {
     private final PieceMapper pieceMapper;
 
     private static final Duration REWARD_TTL = Duration.ofMinutes(10); // 10분만 유효
+    private final PuzzleSlotRepository puzzleSlotRepository;
 
     @Transactional
     public PieceResponse addPieceToPuzzle(Long userId, long itemId) {
@@ -61,7 +63,10 @@ public class DailyCheckService {
     @Transactional
     public RewardCandidate generateRewardCandidates(Long userId) {
         log.info("[DailyCheckService] 출석 보상 목록 생성 요청 - userId = {}", userId);
-        entityFinder.getUserOrThrow(userId);
+        User user = entityFinder.getUserOrThrow(userId);
+
+        // 이미 출석 했다면 보상 선택 불가
+        if(user.getIsCheckedIn()) throw new UserException(ErrorCode.ALREADY_REWARDED);
 
         return randomRewardPickAndGenerateToken(userId);
     }
@@ -80,11 +85,14 @@ public class DailyCheckService {
         // redis로부터 보상후보 조회
         List<Long> candidateIds = getCandidateIdsFromRedis(key);
 
-        // 선택한 아이템이 보상 후보에 선택됐는지 검증
+        // 선택한 아이템이 보상 후보에서 선택됐는지 검증
         validateSelectedItemInCandidates(userId, request, candidateIds);
 
         // 출석 상태 즉시 업데이트 & 저장 & 트랜잭션 보장
         updateUserCheckedIn(userId);
+
+        // 출석 시 점수 제공 (+10pt)
+        user.addScore(10);
 
         // 이미 해당 아이템이 퍼즐에 추가되어있는지 검증
         checkAlreadyAddedToPuzzle(user, item);
@@ -92,11 +100,65 @@ public class DailyCheckService {
         // piece 저장
         savePiece(user, item);
 
+        // 여기서 퍼즐 테마 완성 여부 체크
+        rewardIfThemeCompleted(user, item);
+
+        // 레어도에 따라 점수 차등 지급
+        Rarity rarity = item.getRarity();
+        rewardScoreToUser(user, rarity);
+
         log.info("[DailyCheckService] 출석 보상 정상 지급  - userId = {}", userId);
         redisTemplate.delete(key);
     }
 
     // ------------------------------------------ 아래는 메서드 ------------------------------------------ //
+
+    // 해당 조각으로 완성된 테마가 있다면 100pt 지급
+    private void rewardIfThemeCompleted(User user, Item item) {
+
+        // 해당 아이템의 테마 확인
+        Theme theme = puzzleSlotRepository.findByItem(item).getTheme();
+
+        // 테마들을 순회
+        List<PuzzleSlot> themeSlots = puzzleSlotRepository.findByTheme(theme);
+
+        // 해당 테마에 속한 아이템들의 id 리스트
+        List<Long> itemIdList = themeSlots.stream()
+                .map(PuzzleSlot::getItem)
+                .map(Item::getId)
+                .toList();
+
+        // 해당 유저가 그 아이디의 아이템들을 전부 가지고 있는지 확인
+        Set<Long> userItemIds = pieceRepository.findByUserId(user.getId()).stream()
+                .map(piece -> piece.getItem().getId())
+                .collect(Collectors.toSet());
+
+        // 유저가 가진 아이템 집합에 테망의 아이템 집합이 속하는지 확인
+        boolean completed = userItemIds.containsAll(itemIdList);
+
+        // 만약 테마 완성이 됐다면 100 지급
+        if(completed) {
+            user.addScore(100);
+        }
+    }
+
+    // 아이템 등급에 따른 보상 지급
+    private void rewardScoreToUser(User user, Rarity rarity) {
+        // 출석 보상으로 점수 제공
+        switch (rarity) {
+            case S:
+                user.addScore(10);
+                break;
+            case A:
+                user.addScore(7);
+                break;
+            case B:
+                user.addScore(5);
+                break;
+            default:
+                break;
+        }
+    }
 
     // redis로부터 보상후보 조회
     private List<Long> getCandidateIdsFromRedis(String key) {

--- a/src/main/java/_team/earnedit/service/NaverShoppingService.java
+++ b/src/main/java/_team/earnedit/service/NaverShoppingService.java
@@ -1,78 +1,78 @@
-//package _team.earnedit.service;
-//
-//import _team.earnedit.dto.item.NaverProductResponse;
-//import _team.earnedit.dto.item.NaverProductSearchRequest;
-//import _team.earnedit.global.ErrorCode;
-//import _team.earnedit.global.exception.CustomException;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.http.*;
-//import org.springframework.http.client.SimpleClientHttpRequestFactory;
-//import org.springframework.stereotype.Service;
-//import org.springframework.web.client.RestTemplate;
-//import org.springframework.web.util.UriComponentsBuilder;
-//
-//import java.net.URI;
-//import java.util.Collections;
-//
-//@Service
-//@Slf4j
-//public class NaverShoppingService {
-//
-//    private final RestTemplate restTemplate;
-//
-//    @Value("${naver.api.client-id}")
-//    private String clientId;
-//
-//    @Value("${naver.api.client-secret}")
-//    private String clientSecret;
-//
-//    private static final String NAVER_SHOPPING_API_URL = "https://openapi.naver.com/v1/search/shop.json";
-//
-//    public NaverShoppingService() {
-//        // RestTemplate을 직접 생성하여 타임아웃 설정
-//        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-//        factory.setConnectTimeout(10000); // 10초
-//        factory.setReadTimeout(30000);    // 30초
-//        this.restTemplate = new RestTemplate(factory);
-//    }
-//
-//    public NaverProductResponse searchProducts(NaverProductSearchRequest request) {
-//        log.info("네이버 쇼핑 API 호출 - query: {}", request.getQuery());
-//
-//        try {
-//            URI uri = UriComponentsBuilder.fromHttpUrl(NAVER_SHOPPING_API_URL)
-//                    .queryParam("query", request.getQuery())
-//                    .queryParam("display", request.getDisplay())
-//                    .queryParam("start", request.getStart())
-//                    .queryParam("sort", request.getSort())
-//                    .build()
-//                    .encode()
-//                    .toUri();
-//
-//            HttpHeaders headers = new HttpHeaders();
-//            headers.set("X-Naver-Client-Id", clientId);
-//            headers.set("X-Naver-Client-Secret", clientSecret);
-//            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
-//
-//            ResponseEntity<NaverProductResponse> response = restTemplate.exchange(
-//                    uri,
-//                    HttpMethod.GET,
-//                    new HttpEntity<>(headers),
-//                    NaverProductResponse.class
-//            );
-//
-//            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-//                return response.getBody();
-//            } else {
-//                log.error("네이버 API 응답 오류 - status: {}", response.getStatusCode());
-//                throw new CustomException(ErrorCode.NAVER_API_ERROR);
-//            }
-//
-//        } catch (Exception e) {
-//            log.error("네이버 API 호출 실패 - query: {}", request.getQuery(), e);
-//            throw new CustomException(ErrorCode.NAVER_API_ERROR);
-//        }
-//    }
-//}
+package _team.earnedit.service;
+
+import _team.earnedit.dto.item.NaverProductResponse;
+import _team.earnedit.dto.item.NaverProductSearchRequest;
+import _team.earnedit.global.ErrorCode;
+import _team.earnedit.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Collections;
+
+@Service
+@Slf4j
+public class NaverShoppingService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${naver.api.client-id}")
+    private String clientId;
+
+    @Value("${naver.api.client-secret}")
+    private String clientSecret;
+
+    private static final String NAVER_SHOPPING_API_URL = "https://openapi.naver.com/v1/search/shop.json";
+
+    public NaverShoppingService() {
+        // RestTemplate을 직접 생성하여 타임아웃 설정
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000); // 10초
+        factory.setReadTimeout(30000);    // 30초
+        this.restTemplate = new RestTemplate(factory);
+    }
+
+    public NaverProductResponse searchProducts(NaverProductSearchRequest request) {
+        log.info("네이버 쇼핑 API 호출 - query: {}", request.getQuery());
+
+        try {
+            URI uri = UriComponentsBuilder.fromHttpUrl(NAVER_SHOPPING_API_URL)
+                    .queryParam("query", request.getQuery())
+                    .queryParam("display", request.getDisplay())
+                    .queryParam("start", request.getStart())
+                    .queryParam("sort", request.getSort())
+                    .build()
+                    .encode()
+                    .toUri();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-Naver-Client-Id", clientId);
+            headers.set("X-Naver-Client-Secret", clientSecret);
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+            ResponseEntity<NaverProductResponse> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    NaverProductResponse.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            } else {
+                log.error("네이버 API 응답 오류 - status: {}", response.getStatusCode());
+                throw new CustomException(ErrorCode.NAVER_API_ERROR);
+            }
+
+        } catch (Exception e) {
+            log.error("네이버 API 호출 실패 - query: {}", request.getQuery(), e);
+            throw new CustomException(ErrorCode.NAVER_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/_team/earnedit/service/ProductService.java
+++ b/src/main/java/_team/earnedit/service/ProductService.java
@@ -1,177 +1,177 @@
-//package _team.earnedit.service;
-//
-//import _team.earnedit.dto.item.NaverProductSearchRequest;
-//import _team.earnedit.dto.item.NaverProductResponse;
-//import _team.earnedit.dto.item.ProductSearchResponse;
-//import _team.earnedit.entity.SearchItem;
-//import _team.earnedit.repository.SearchItemRepository;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.cache.annotation.Cacheable;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.util.List;
-//import java.util.concurrent.CompletableFuture;
-//import java.util.stream.Collectors;
-//
-//@Service
-//@Slf4j
-//@RequiredArgsConstructor
-//public class ProductService {
-//
-//    private final NaverShoppingService naverShoppingService;
-//    private final FileUploadService fileUploadService;
-//    private final SearchItemRepository searchItemRepository;
-//
-//    @Transactional
-//    public ProductSearchResponse searchProducts(NaverProductSearchRequest request) {
-//        log.info("상품 검색 - query: {}, useCache: {}", request.getQuery(), request.getUseCache());
-//
-//        // 캐시 확인
-//        if (request.getUseCache()) {
-//            ProductSearchResponse cached = getCachedResult(request.getQuery());
-//            if (cached != null) return cached;
-//        }
-//
-//        // 네이버 API 호출
-//        NaverProductResponse naverResponse = naverShoppingService.searchProducts(request);
-//        if (naverResponse.getItems() == null || naverResponse.getItems().isEmpty()) {
-//            return createEmptyResponse(request);
-//        }
-//
-//        // 비동기 처리
-//        List<CompletableFuture<ProductSearchResponse.ProductItem>> futures = naverResponse.getItems().stream()
-//                .map(item -> CompletableFuture.supplyAsync(() -> processItem(item, request.getUseCache())))
-//                .collect(Collectors.toList());
-//
-//        List<ProductSearchResponse.ProductItem> products = futures.stream()
-//                .map(CompletableFuture::join)
-//                .collect(Collectors.toList());
-//
-//        return ProductSearchResponse.builder()
-//                .searchInfo(ProductSearchResponse.SearchInfo.builder()
-//                        .totalCount(naverResponse.getTotal())
-//                        .query(request.getQuery())
-//                        .useCache(request.getUseCache())
-//                        .removeBackground(request.getRemoveBackground())
-//                        .display(request.getDisplay())
-//                        .build())
-//                .products(products)
-//                .build();
-//    }
-//
-//    private ProductSearchResponse.ProductItem processItem(NaverProductResponse.NaverProductItem item, Boolean useCache) {
-//        try {
-//            String s3ImageUrl = fileUploadService.uploadImageFromUrl(item.getImage());
-//            ProductSearchResponse.ProductItem productItem = ProductSearchResponse.ProductItem.from(item, s3ImageUrl);
-//
-//            // useCache 여부와 관계없이 항상 캐시 업데이트 (최신 데이터 유지)
-//            saveOrUpdateCache(item, s3ImageUrl);
-//
-//            return productItem;
-//        } catch (Exception e) {
-//            log.error("상품 처리 실패 - productId: {}", item.getProductId(), e);
-//            return ProductSearchResponse.ProductItem.from(item, item.getImage());
-//        }
-//    }
-//
-//    @Cacheable(value = "productSearch", key = "#query")
-//    public ProductSearchResponse getCachedResult(String query) {
-//        try {
-//            List<SearchItem> items = searchItemRepository.findByNameContainingIgnoreCase(query)
-//                    .stream().limit(20).collect(Collectors.toList());
-//
-//            if (items.isEmpty()) return null;
-//
-//            List<ProductSearchResponse.ProductItem> products = items.stream()
-//                    .map(this::toProductItem)
-//                    .collect(Collectors.toList());
-//
-//            return ProductSearchResponse.builder()
-//                    .searchInfo(ProductSearchResponse.SearchInfo.builder()
-//                            .totalCount(products.size())
-//                            .query(query)
-//                            .useCache(true)
-//                            .removeBackground(false)
-//                            .display(20) // 캐시 조회시 기본값
-//                            .build())
-//                    .products(products)
-//                    .build();
-//        } catch (Exception e) {
-//            log.error("캐시 조회 실패 - query: {}", query, e);
-//            return null;
-//        }
-//    }
-//
-//    private void saveOrUpdateCache(NaverProductResponse.NaverProductItem naverItem, String s3ImageUrl) {
-//        try {
-//            SearchItem existing = searchItemRepository.findByProductId(naverItem.getProductId());
-//            if (existing != null) {
-//                updateSearchItem(existing, naverItem, s3ImageUrl);
-//            } else {
-//                searchItemRepository.save(createSearchItem(naverItem, s3ImageUrl));
-//            }
-//        } catch (Exception e) {
-//            log.warn("캐시 저장 실패 - productId: {}", naverItem.getProductId(), e);
-//        }
-//    }
-//
-//    private SearchItem createSearchItem(NaverProductResponse.NaverProductItem item, String s3ImageUrl) {
-//        return SearchItem.builder()
-//                .productId(item.getProductId())
-//                .name(removeHtmlTags(item.getTitle()))
-//                .maker(item.getMaker() != null ? item.getMaker() : "")
-//                .price(parsePrice(item.getLprice()))
-//                .imageUrl(s3ImageUrl)
-//                .productUrl(item.getLink())
-//                .build();
-//    }
-//
-//    private void updateSearchItem(SearchItem searchItem, NaverProductResponse.NaverProductItem naverItem, String s3ImageUrl) {
-//        searchItem.setName(removeHtmlTags(naverItem.getTitle()));
-//        searchItem.setMaker(naverItem.getMaker() != null ? naverItem.getMaker() : "");
-//        searchItem.setPrice(parsePrice(naverItem.getLprice()));
-//        searchItem.setImageUrl(s3ImageUrl);
-//        searchItem.setProductUrl(naverItem.getLink());
-//        searchItemRepository.save(searchItem);
-//    }
-//
-//    private ProductSearchResponse.ProductItem toProductItem(SearchItem item) {
-//        return ProductSearchResponse.ProductItem.builder()
-//                .id(item.getProductId())
-//                .name(item.getName())
-//                .price(Double.valueOf(item.getPrice()))
-//                .imageUrl(item.getImageUrl())
-//                .url(item.getProductUrl())
-//                .maker(item.getMaker()) // SearchItem의 maker 필드 사용
-//                .build();
-//    }
-//
-//    private String removeHtmlTags(String text) {
-//        if (text == null) return null;
-//        return text.replaceAll("<[^>]*>", "");
-//    }
-//
-//    private Long parsePrice(String priceStr) {
-//        if (priceStr == null || priceStr.isEmpty()) return 0L;
-//        try {
-//            return Long.parseLong(priceStr);
-//        } catch (NumberFormatException e) {
-//            return 0L;
-//        }
-//    }
-//
-//    private ProductSearchResponse createEmptyResponse(NaverProductSearchRequest request) {
-//        return ProductSearchResponse.builder()
-//                .searchInfo(ProductSearchResponse.SearchInfo.builder()
-//                        .totalCount(0)
-//                        .query(request.getQuery())
-//                        .useCache(request.getUseCache())
-//                        .removeBackground(request.getRemoveBackground())
-//                        .display(request.getDisplay())
-//                        .build())
-//                .products(List.of())
-//                .build();
-//    }
-//}
+package _team.earnedit.service;
+
+import _team.earnedit.dto.item.NaverProductSearchRequest;
+import _team.earnedit.dto.item.NaverProductResponse;
+import _team.earnedit.dto.item.ProductSearchResponse;
+import _team.earnedit.entity.SearchItem;
+import _team.earnedit.repository.SearchItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final NaverShoppingService naverShoppingService;
+    private final FileUploadService fileUploadService;
+    private final SearchItemRepository searchItemRepository;
+
+    @Transactional
+    public ProductSearchResponse searchProducts(NaverProductSearchRequest request) {
+        log.info("상품 검색 - query: {}, useCache: {}", request.getQuery(), request.getUseCache());
+
+        // 캐시 확인
+        if (request.getUseCache()) {
+            ProductSearchResponse cached = getCachedResult(request.getQuery());
+            if (cached != null) return cached;
+        }
+
+        // 네이버 API 호출
+        NaverProductResponse naverResponse = naverShoppingService.searchProducts(request);
+        if (naverResponse.getItems() == null || naverResponse.getItems().isEmpty()) {
+            return createEmptyResponse(request);
+        }
+
+        // 비동기 처리
+        List<CompletableFuture<ProductSearchResponse.ProductItem>> futures = naverResponse.getItems().stream()
+                .map(item -> CompletableFuture.supplyAsync(() -> processItem(item, request.getUseCache())))
+                .collect(Collectors.toList());
+
+        List<ProductSearchResponse.ProductItem> products = futures.stream()
+                .map(CompletableFuture::join)
+                .collect(Collectors.toList());
+
+        return ProductSearchResponse.builder()
+                .searchInfo(ProductSearchResponse.SearchInfo.builder()
+                        .totalCount(naverResponse.getTotal())
+                        .query(request.getQuery())
+                        .useCache(request.getUseCache())
+                        .removeBackground(request.getRemoveBackground())
+                        .display(request.getDisplay())
+                        .build())
+                .products(products)
+                .build();
+    }
+
+    private ProductSearchResponse.ProductItem processItem(NaverProductResponse.NaverProductItem item, Boolean useCache) {
+        try {
+            String s3ImageUrl = fileUploadService.uploadImageFromUrl(item.getImage());
+            ProductSearchResponse.ProductItem productItem = ProductSearchResponse.ProductItem.from(item, s3ImageUrl);
+
+            // useCache 여부와 관계없이 항상 캐시 업데이트 (최신 데이터 유지)
+            saveOrUpdateCache(item, s3ImageUrl);
+
+            return productItem;
+        } catch (Exception e) {
+            log.error("상품 처리 실패 - productId: {}", item.getProductId(), e);
+            return ProductSearchResponse.ProductItem.from(item, item.getImage());
+        }
+    }
+
+    @Cacheable(value = "productSearch", key = "#query")
+    public ProductSearchResponse getCachedResult(String query) {
+        try {
+            List<SearchItem> items = searchItemRepository.findByNameContainingIgnoreCase(query)
+                    .stream().limit(20).collect(Collectors.toList());
+
+            if (items.isEmpty()) return null;
+
+            List<ProductSearchResponse.ProductItem> products = items.stream()
+                    .map(this::toProductItem)
+                    .collect(Collectors.toList());
+
+            return ProductSearchResponse.builder()
+                    .searchInfo(ProductSearchResponse.SearchInfo.builder()
+                            .totalCount(products.size())
+                            .query(query)
+                            .useCache(true)
+                            .removeBackground(false)
+                            .display(20) // 캐시 조회시 기본값
+                            .build())
+                    .products(products)
+                    .build();
+        } catch (Exception e) {
+            log.error("캐시 조회 실패 - query: {}", query, e);
+            return null;
+        }
+    }
+
+    private void saveOrUpdateCache(NaverProductResponse.NaverProductItem naverItem, String s3ImageUrl) {
+        try {
+            SearchItem existing = searchItemRepository.findByProductId(naverItem.getProductId());
+            if (existing != null) {
+                updateSearchItem(existing, naverItem, s3ImageUrl);
+            } else {
+                searchItemRepository.save(createSearchItem(naverItem, s3ImageUrl));
+            }
+        } catch (Exception e) {
+            log.warn("캐시 저장 실패 - productId: {}", naverItem.getProductId(), e);
+        }
+    }
+
+    private SearchItem createSearchItem(NaverProductResponse.NaverProductItem item, String s3ImageUrl) {
+        return SearchItem.builder()
+                .productId(item.getProductId())
+                .name(removeHtmlTags(item.getTitle()))
+                .maker(item.getMaker() != null ? item.getMaker() : "")
+                .price(parsePrice(item.getLprice()))
+                .imageUrl(s3ImageUrl)
+                .productUrl(item.getLink())
+                .build();
+    }
+
+    private void updateSearchItem(SearchItem searchItem, NaverProductResponse.NaverProductItem naverItem, String s3ImageUrl) {
+        searchItem.setName(removeHtmlTags(naverItem.getTitle()));
+        searchItem.setMaker(naverItem.getMaker() != null ? naverItem.getMaker() : "");
+        searchItem.setPrice(parsePrice(naverItem.getLprice()));
+        searchItem.setImageUrl(s3ImageUrl);
+        searchItem.setProductUrl(naverItem.getLink());
+        searchItemRepository.save(searchItem);
+    }
+
+    private ProductSearchResponse.ProductItem toProductItem(SearchItem item) {
+        return ProductSearchResponse.ProductItem.builder()
+                .id(item.getProductId())
+                .name(item.getName())
+                .price(Double.valueOf(item.getPrice()))
+                .imageUrl(item.getImageUrl())
+                .url(item.getProductUrl())
+                .maker(item.getMaker()) // SearchItem의 maker 필드 사용
+                .build();
+    }
+
+    private String removeHtmlTags(String text) {
+        if (text == null) return null;
+        return text.replaceAll("<[^>]*>", "");
+    }
+
+    private Long parsePrice(String priceStr) {
+        if (priceStr == null || priceStr.isEmpty()) return 0L;
+        try {
+            return Long.parseLong(priceStr);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private ProductSearchResponse createEmptyResponse(NaverProductSearchRequest request) {
+        return ProductSearchResponse.builder()
+                .searchInfo(ProductSearchResponse.SearchInfo.builder()
+                        .totalCount(0)
+                        .query(request.getQuery())
+                        .useCache(request.getUseCache())
+                        .removeBackground(request.getRemoveBackground())
+                        .display(request.getDisplay())
+                        .build())
+                .products(List.of())
+                .build();
+    }
+}

--- a/src/main/java/_team/earnedit/service/RewardCheckInService.java
+++ b/src/main/java/_team/earnedit/service/RewardCheckInService.java
@@ -20,4 +20,13 @@ public class RewardCheckInService {
         user.checkIn();
         userRepository.save(user);
     }
+
+    // 출석 시 점수 제공 (+10pt) & 트랜잭션 분리
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void giveAttendanceScore(Long userId) {
+        User user = entityFinder.getUserOrThrow(userId);
+
+        user.addScore(10);
+        userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 상품 검색 API 복구 및 API 요청 형식 변경 및 준영님 요청사항 처리

---

## ✨ 주요 변경 사항
- 상품 검색 API 복구 및 API 요청 형식 변경
- @ModelAttribute -> @RequestParam 변경
- 배포 서버 측 .env 업데이트(naverShopping API 관련 환경변수 추가)
- 메인페이지 정보 조회 시, 유저의 isPublic 필드 응답 추가
- 출석 점수 지급 로직이 트랜잭션에 묶여 예외 발생 시 보상 지급 안되는 버그 수정

---

## 🖼️ 기능 살펴 보기
> <img width="1530" height="1461" alt="image" src="https://github.com/user-attachments/assets/dd86fdda-ad69-4682-b904-5b6d4effbe12" />
- 상품 검색 API 로컬에서 정상 동작 확인

> <img width="1534" height="1149" alt="image" src="https://github.com/user-attachments/assets/4cb73386-6e99-4260-93cb-083f74f676e6" />
- 메인페이지 정보 조회 시, 유저의 isPublic 필드 응답 추가


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서
