### PR TITLE
ref: 2글자 닉네임 랭크 페이지에서 동* 과 같이 나타내도록 수정

### DIFF
--- a/src/main/java/_team/earnedit/service/RankService.java
+++ b/src/main/java/_team/earnedit/service/RankService.java
@@ -56,6 +56,8 @@ public class RankService {
                         if (nickname.length() > 2) {
                             maskedNickname = nickname.substring(0, 2)
                                     + "*".repeat(nickname.length() - 2);
+                        } else if (nickname.length() == 2) { // 2글자 닉네임의 경우 앞의 1글자만 표시 ex) 동훈 -> 동*
+                            maskedNickname = nickname.charAt(0) + "*";
                         } else {
                             // 닉네임이 2글자 이하인 경우 전부 * 처리
                             maskedNickname = "*".repeat(nickname.length());


### PR DESCRIPTION
## 📌 작업 개요
- 2글자 닉네임 랭크 페이지에서 동* 과 같이 나타내도록 수정

---

## ✨ 주요 변경 사항
- 2글자 닉네임 랭크 페이지에서 동* 과 같이 나타내도록 수정

---

## 🖼️ 기능 살펴 보기
> <img width="1323" height="452" alt="image" src="https://github.com/user-attachments/assets/a2dce486-6493-4009-851f-b85b0f9d93b5" />
- 비공개 처리
---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- Swagger UI

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서

