### PR TITLE
Ref/wish starWish 응답에 (생성일,수정일) 추가, 위시페이지 조회 시, star순서 반영안된 문제 수정

### DIFF
--- a/src/main/java/_team/earnedit/controller/WishController.java
+++ b/src/main/java/_team/earnedit/controller/WishController.java
@@ -2,7 +2,6 @@ package _team.earnedit.controller;
 
 import _team.earnedit.dto.PagedResponse;
 import _team.earnedit.dto.jwt.JwtUserInfoDto;
-import _team.earnedit.dto.profile.PublicUserInfoResponse;
 import _team.earnedit.dto.wish.*;
 import _team.earnedit.global.ApiResponse;
 import _team.earnedit.service.WishService;
@@ -13,7 +12,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -25,8 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/_team/earnedit/dto/star/StarSummaryResponse.java
+++ b/src/main/java/_team/earnedit/dto/star/StarSummaryResponse.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 public class StarSummaryResponse {
@@ -36,4 +38,10 @@ public class StarSummaryResponse {
 
     @Schema(description = "순서", example = "1~5")
     private int rank;
+
+    @Schema(description = "생성 시각", example = "2025-07-27T13:45:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각", example = "2025-07-28T08:15:00")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/_team/earnedit/service/ProfileService.java
+++ b/src/main/java/_team/earnedit/service/ProfileService.java
@@ -191,6 +191,8 @@ public class ProfileService {
                         .starred(star.getWish().isStarred())
                         .isBought(star.getWish().isBought())
                         .rank(star.getRank())
+                        .createdAt(star.getWish().getCreatedAt())
+                        .updatedAt(star.getWish().getUpdatedAt())
                         .build())
                 .toList();
 

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -244,8 +244,8 @@ public class WishService {
                         .starred(star.getWish().isStarred())
                         .isBought(star.getWish().isBought())
                         .rank(star.getRank())
-                        .createdAt(star.getUser().getCreatedAt())
-                        .updatedAt(star.getUser().getUpdatedAt())
+                        .createdAt(star.getWish().getCreatedAt())
+                        .updatedAt(star.getWish().getUpdatedAt())
                         .build())
                 .toList();
 

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -3,7 +3,6 @@ package _team.earnedit.service;
 import _team.earnedit.dto.PagedResponse;
 import _team.earnedit.dto.profile.ProfileInfoResponseDto;
 import _team.earnedit.dto.profile.PublicUserInfoResponse;
-import _team.earnedit.dto.star.StarListResponse;
 import _team.earnedit.dto.star.StarSummaryResponse;
 import _team.earnedit.dto.wish.*;
 import _team.earnedit.entity.*;
@@ -245,6 +244,8 @@ public class WishService {
                         .starred(star.getWish().isStarred())
                         .isBought(star.getWish().isBought())
                         .rank(star.getRank())
+                        .createdAt(star.getUser().getCreatedAt())
+                        .updatedAt(star.getUser().getUpdatedAt())
                         .build())
                 .toList();
 

--- a/src/main/java/_team/earnedit/service/WishService.java
+++ b/src/main/java/_team/earnedit/service/WishService.java
@@ -231,7 +231,7 @@ public class WishService {
                 .toList();
 
         // starList 조회 및 생성
-        List<Star> starList = starRepository.findByUserId(userId);
+        List<Star> starList = starRepository.findByUserIdOrderByRankAsc(userId);
         List<StarSummaryResponse> mappedStarList = starList.stream()
                 .map(star -> StarSummaryResponse.builder()
                         .starId(star.getId())


### PR DESCRIPTION
## 📌 작업 개요
- starWish 응답에 (생성일,수정일) 추가, 위시페이지 조회 시, star순서 반영안된 문제 수정

---

## ✨ 주요 변경 사항
- StarSummaryResponse에 createdAt, updatedAt 추가
- 위시 페이지 조회 API star조회 메서드 findByUserId -> findByUserIdOrderByRankAsc

---

## 🖼️ 기능 살펴 보기
> 두 API 모두 테스트 완료
- 이미지 삽입 안한 이유: 응답이 너무 길어 사진으로 보여주기 힘들어서 스크린샷은 부득이하게 없이 pr 올리겠습니다.
---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
1. 코드 수정 후 위시페이지 조회API 호출 후 star 순서 확인 (예시: wishId = [9, 5, 4, 2, 1])
2. 순서 변경 API 호출(예시: 변경후 wishId = [1, 2, 4, 9, 5]
3. 다시 위시페이지 조회 API 호출, 변경된 순서 확인 후 종료

---

## 💬 기타 참고 사항


---

## 📎 관련 이슈 / 문서
- 관련 이슈 번호: `close #123`
- 기획서, 디자인, API 문서 등 첨부
