### PR TITLE
Feat/noti admin page : 관리자페이지 중 알림전송 페이지 구현(타임리프)

### DIFF
--- a/src/main/java/_team/earnedit/controller/admin/FcmAdminController.java
+++ b/src/main/java/_team/earnedit/controller/admin/FcmAdminController.java
@@ -1,0 +1,74 @@
+package _team.earnedit.controller.admin;
+
+import _team.earnedit.entity.MessageTemplate;
+import _team.earnedit.repository.MessageTemplateRepository;
+import _team.earnedit.service.notification.FcmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Controller
+@RequestMapping("/admin/fcm")
+@RequiredArgsConstructor
+public class FcmAdminController {
+
+    private final FcmService fcmService;
+    private final MessageTemplateRepository templateRepo;
+
+    // 관리자 폼 (GET)
+    @GetMapping("/send")
+    public String sendForm(Model model) {
+        model.addAttribute("templates", templateRepo.findByActiveTrue()); // 관리자에서 템플릿 목록 보기용
+        model.addAttribute("defaultTopic", "global_notifications");
+        return "admin/fcm-send";
+    }
+
+    // 즉시 전송: title/body 로 글로벌(또는 topic) 전송 (폼에서 POST)
+    @PostMapping("/send")
+    public String sendImmediate(
+            @RequestParam String topic,
+            @RequestParam String title,
+            @RequestParam String body,
+            @RequestParam(required = false) Map<String, String> data,
+            Model model
+    ) {
+        try {
+            // null/empty 처리를 간단히
+            if (topic == null || topic.isBlank()) topic = "global_notifications";
+            fcmService.sendToTopic(topic, title, body, data);
+            model.addAttribute("success", "메시지 전송 성공");
+        } catch (Exception e) {
+            log.error("Immediate send failed", e);
+            model.addAttribute("error", "전송 실패: " + e.getMessage());
+        }
+        model.addAttribute("templates", templateRepo.findByActiveTrue());
+        model.addAttribute("defaultTopic", topic);
+        return "admin/fcm-send";
+    }
+
+    // 템플릿 기반 전송: 선택된 템플릿을 global 토픽으로 전송 (관리자 버튼용)
+    @PostMapping("/send/template/{id}")
+    public String sendTemplateGlobal(@PathVariable Long id, Model model) {
+        Optional<MessageTemplate> t = templateRepo.findById(id);
+        if (t.isEmpty()) {
+            model.addAttribute("error", "템플릿을 찾을 수 없음");
+        } else {
+            try {
+                fcmService.sendGlobal(t.get());
+                model.addAttribute("success", "템플릿 전송 성공");
+            } catch (Exception e) {
+                log.error("Template send failed", e);
+                model.addAttribute("error", "템플릿 전송 실패: " + e.getMessage());
+            }
+        }
+        model.addAttribute("templates", templateRepo.findByActiveTrue());
+        model.addAttribute("defaultTopic", "global_notifications");
+        return "admin/fcm-send";
+    }
+}

--- a/src/main/java/_team/earnedit/repository/MessageTemplateRepository.java
+++ b/src/main/java/_team/earnedit/repository/MessageTemplateRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface MessageTemplateRepository extends JpaRepository<MessageTemplate, Long> {
     List<MessageTemplate> findByCategoryAndActiveTrue(MessageTemplate.Category category);
 
-    Object findByActiveTrue();
+    List<MessageTemplate> findByActiveTrue();
 }

--- a/src/main/java/_team/earnedit/repository/MessageTemplateRepository.java
+++ b/src/main/java/_team/earnedit/repository/MessageTemplateRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface MessageTemplateRepository extends JpaRepository<MessageTemplate, Long> {
     List<MessageTemplate> findByCategoryAndActiveTrue(MessageTemplate.Category category);
+
+    Object findByActiveTrue();
 }

--- a/src/main/java/_team/earnedit/service/notification/ScheduledNotificationService.java
+++ b/src/main/java/_team/earnedit/service/notification/ScheduledNotificationService.java
@@ -35,7 +35,7 @@ public class ScheduledNotificationService {
     // 퇴근시간 (19:00 KST)
     @Scheduled(cron = "0 0 19 * * *")
     public void sendEveningQuote() {
-        sendRandom(Category.QUOTE);
+        sendRandom(Category.ENCOURAGE);
     }
 
     // db에 저장된 카테고리별 메시지 중 랜덤 발송

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -45,6 +45,7 @@
     <li><a th:href="@{/admin/items/new}">➕ 아이템 등록</a></li>
     <li><a th:href="@{/admin/puzzle-slots/view}">🧩 퍼즐 슬롯 그리드 보기</a></li>
     <li><a th:href="@{/admin/puzzle-slots/grid}">🧩 퍼즐 슬롯 드래그 편집</a></li>
+    <li><a th:href="@{/admin/fcm/send}">📣 FCM 전송 (관리자)</a></li>
 </ul>
 </body>
 </html>

--- a/src/main/resources/templates/admin/fcm-send.html
+++ b/src/main/resources/templates/admin/fcm-send.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <title>FCM 전송 - 관리자</title>
+  <style>
+    body { font-family: 'Arial', sans-serif; margin: 2rem; background:#f6f7fb; color:#222; }
+    .card { background:white; padding:1rem; border-radius:8px; box-shadow:0 6px 18px rgba(0,0,0,0.06); margin-bottom:1rem; }
+    label { display:block; font-weight:600; margin-top:0.5rem; }
+    input[type=text], textarea, select { width:100%; padding:8px; margin-top:6px; border-radius:6px; border:1px solid #ddd; }
+    button { margin-top:12px; padding:8px 14px; border-radius:8px; border:0; cursor:pointer; background:#007bff; color:white; }
+    .success { color:green; }
+    .error { color:#b00020; }
+    .templates { display:grid; grid-template-columns: 1fr 1fr; gap:12px; margin-top:12px; }
+    .tpl { padding:10px; border-radius:6px; background:#fff; border:1px solid #eee; }
+    .small-btn { padding:6px 8px; font-size:0.9rem; background:#28a745; color:white; border-radius:6px; border:0; cursor:pointer; }
+  </style>
+</head>
+<body>
+<h1>📣 FCM 전송 (관리자)</h1>
+
+<div th:if="${success}" class="card success" th:text="${success}"></div>
+<div th:if="${error}" class="card error" th:text="${error}"></div>
+
+<div class="card">
+  <h3>즉시 전송 (직접 입력)</h3>
+  <form th:action="@{/admin/fcm/send}" method="post">
+    <label>Topic</label>
+    <input type="text" name="topic" th:value="${defaultTopic}" placeholder="global_notifications" />
+
+    <label>Title</label>
+    <input type="text" name="title" placeholder="제목을 입력하세요" required />
+
+    <label>Body</label>
+    <textarea name="body" rows="3" placeholder="본문을 입력하세요" required></textarea>
+
+    <label>데이터 (옵션, key=value 형태로 쉼표로 구분)</label>
+    <input type="text" name="data" placeholder="exampleKey=exampleValue,foo=bar" />
+
+    <button type="submit">지금 전송</button>
+  </form>
+  <p style="margin-top:8px; color:#666; font-size:0.9rem;">Tip: 글로벌 전송을 원하면 topic을 <code>global_notifications</code> 로 사용하세요.</p>
+</div>
+
+<div class="card">
+  <h3>템플릿 목록 (DB)</h3>
+  <div class="templates">
+    <div class="tpl" th:each="tpl : ${templates}">
+      <div><strong th:text="${tpl.title}">제목</strong> <small style="color:#888" th:text="${tpl.category}">카테고리</small></div>
+      <div th:text="${tpl.body}" style="margin:8px 0; color:#333;">본문</div>
+      <form th:action="@{|/admin/fcm/send/template/${tpl.id}|}" method="post">
+        <button type="submit" class="small-btn">글로벌로 전송</button>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  // 폼에서 data 입력을 key=value,comma 형식을 서버로 보내는 간단 처리 (서버에서는 Map으로 받을 수 있도록)
+  document.querySelector('form[th\\:action="@{/admin/fcm/send}"]')?.addEventListener('submit', function (ev) {
+    // 폼 submit 전 data 필드가 있으면 key=value 쌍으로 input을 여러개 만들어서 전송
+    const dataStr = this.querySelector('input[name="data"]').value.trim();
+    if (!dataStr) return; // 없음
+    // parse into hidden inputs
+    const pairs = dataStr.split(',').map(s => s.trim()).filter(Boolean);
+    pairs.forEach(pair => {
+      const [k, v] = pair.split('=').map(s => s?.trim());
+      if (k && v !== undefined) {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        // spring will interpret repeated params as map? safe approach: name="data[key]"
+        input.name = 'data[' + k + ']';
+        input.value = v;
+        this.appendChild(input);
+      }
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 작업 개요
- 관리자페이지 중 알림전송 페이지 구현(타임리프)

---

## ✨ 주요 변경 사항
- 스케줄러를 이용한 일반 전역알림 전송은 db 의 카테고리 중 랜덤으로 전송합니다
- 관리자 알림전송 페이지에서는 db 내용 꺼내지 않고 ! 수기입력으로 즉시 전송 가능합니다

- FcmService에 sendToTopic, sendGlobal 오버로드 메서드 정의
- 관리자페이지용 FcmAdminController 구현
- admin/fcm-send.html 타임리프 페이지 구현 + 대시보드 페이지 추가

---

## 🖼️ 기능 살펴 보기

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 스웨거 ui 관련 코드 추가
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [ ] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [ ] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
    - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 로컬 환경이라 서버 돌아가는거 봐야해요

---

## 📎 관련 이슈 / 문서

